### PR TITLE
Adds new `getVideoData` method to extract video id and thumbnails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "viget/craft-video-embed",
     "description": "Generate an embed URL from a YouTube or Vimeo URL",
     "type": "craft-plugin",
-    "version": "2.0.0",
+    "version": "2.0.2",
     "keywords": [
         "craft",
         "cms",

--- a/src/enums/VideoType.php
+++ b/src/enums/VideoType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace viget\videoembed\enums;
+
+enum VideoType: string
+{
+    case YOUTUBE = 'youtube';
+    case VIMEO = 'vimeo';
+    case UNKNOWN = 'unknown';
+}

--- a/src/helpers/ParsingHelper.php
+++ b/src/helpers/ParsingHelper.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace viget\videoembed\helpers;
+
+use viget\videoembed\enums\VideoType;
+use viget\videoembed\models\VideoData;
+
+class ParsingHelper
+{
+    const YOUTUBE_URLS = ['youtube.com', 'youtu.be'];
+    const VIMEO_URLS = ['vimeo.com'];
+    
+    public static function getVideoDataFromUrl(string $url): ?VideoData
+    {
+        return match(self::getVideoTypeFromUrl($url)) {
+            VideoType::YOUTUBE => VideoData::forYoutube(
+                self::getYouTubeIdFromUrl($url)
+            ),
+            VideoType::VIMEO => VideoData::forVimeo(
+                self::getVimeoIdFromUrl($url)
+            ),
+            default => null,
+        };
+    }
+    
+    public static function getVideoTypeFromUrl(string $url): VideoType
+    {
+        $parsedUrl = parse_url($url);
+        $host = $parsedUrl['host'] ?? null;
+        if (!$host) {
+            return VideoType::UNKNOWN;
+        }
+        
+        $host = str_replace('www.', '', $host);
+        $host = strtolower($host);
+        
+        if (in_array($host, self::YOUTUBE_URLS)) {
+            return VideoType::YOUTUBE;
+        }
+        
+        if (in_array($host, self::VIMEO_URLS)) {
+            return VideoType::VIMEO;
+        }
+        
+        return VideoType::UNKNOWN;
+    }
+    
+    /**
+     * Gets the video id from a YouTube URL
+     */
+    public static function getYouTubeIdFromUrl(string $url): ?string
+    {
+        if (empty($url)) {
+            return null;
+        }
+        
+        $parts = parse_url($url);
+        $query = $parts['query'] ?? null;
+        $path = $parts['path'] ?? null;
+        
+        if ($query) {
+            parse_str($query, $qs);
+            return $qs['v'] ?? $qs['vi'] ?? null;
+        }
+    
+        // Deals with https://youtu.be/X9tg3J5OiYU URLs
+        if ($path) {
+            $explodedPath = explode('/', trim($path, '/'));
+            return $explodedPath[0] ?? null;
+        }
+        
+        return null;
+    }
+    
+    /**
+     * Gets the video id from a Vimeo URL
+     */
+    public static function getVimeoIdFromUrl(string $url): ?string
+    {
+        $parts = parse_url($url);
+        $path = $parts['path'] ?? null;
+        
+        if (!$path) {
+            return null;
+        }
+        
+        $segments = explode('/', trim($path, '/'));
+    
+        return $segments[0] ?? null;
+    }
+
+}

--- a/src/models/VideoData.php
+++ b/src/models/VideoData.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace viget\videoembed\models;
+
+use viget\videoembed\enums\VideoType;
+
+class VideoData
+{
+    public function __construct(
+        public string $type,
+        public string $id,
+        public ?string $image,
+        public string $embedUrl,
+        public string $url,
+    )
+    {
+    }
+    
+    public static function forYoutube(?string $youtubeId): ?static
+    {
+        if (!$youtubeId) {
+            return null;
+        }
+        
+        return new self(
+            type: VideoType::YOUTUBE->value,
+            id: $youtubeId,
+            image: "https://i.ytimg.com/vi/{$youtubeId}/hqdefault.jpg",
+            embedUrl: "https://www.youtube.com/embed/{$youtubeId}",
+            url: "https://www.youtube.com/watch?={$youtubeId}",
+        );
+    }
+    
+    public static function forVimeo(?string $vimeoId): ?static
+    {
+        if (!$vimeoId) {
+            return null;
+        }
+        
+        return new self(
+            type: VideoType::VIMEO->value,
+            id: $vimeoId,
+            image: null, // TODO there isn't an easy way to get this without querying an API or oEmbed endpoint
+            embedUrl: "https://player.vimeo.com/video/{$vimeoId}",
+            url: "https://www.vimeo.com/{$vimeoId}",
+        );
+    }
+}

--- a/src/services/VideoEmbed.php
+++ b/src/services/VideoEmbed.php
@@ -3,9 +3,20 @@
 namespace viget\videoembed\services;
 
 use Craft;
+use viget\videoembed\helpers\ParsingHelper;
+use viget\videoembed\models\VideoData;
 
 class VideoEmbed
 {
+    
+    /**
+     * Takes a YouTube or Vimeo URL and returns metadata for the video
+     */
+    public function getVideoData(string $url): ?VideoData
+    {
+        return ParsingHelper::getVideoDataFromUrl($url);
+    }
+    
     /**
      * Take a YouTube or Vimeo url and return the embed url
      *

--- a/src/services/VideoEmbed.php
+++ b/src/services/VideoEmbed.php
@@ -3,12 +3,13 @@
 namespace viget\videoembed\services;
 
 use Craft;
+use craft\errors\DeprecationException;
 use viget\videoembed\helpers\ParsingHelper;
 use viget\videoembed\models\VideoData;
 
 class VideoEmbed
 {
-    
+
     /**
      * Takes a YouTube or Vimeo URL and returns metadata for the video
      */
@@ -22,9 +23,14 @@ class VideoEmbed
      *
      * @param string $url
      * @return string|null
+     * @throws DeprecationException
+     * @deprecated v2.0.2
+     * @see self::getVideoData()
      */
     public function getEmbedUrl(string $url): ?string
     {
+        Craft::$app->getDeprecator()->log(__METHOD__, 'use getVideoData() instead');
+        
         if ($this->_isYoutube($url)) {
             $urlParts = parse_url($url);
             $query = $urlParts['query'] ?? null;
@@ -42,7 +48,7 @@ class VideoEmbed
 
             return '//www.youtube.com/embed/' . $v;
         }
-    
+
         if ($this->_isShortYoutube($url)) {
             $urlParts = parse_url($url);
             $path = $urlParts['path'] ?? null;
@@ -51,7 +57,7 @@ class VideoEmbed
 
             return '//www.youtube.com/embed' . $path;
         }
-    
+
         if ($this->_isVimeo($url)) {
             $urlParts = parse_url($url);
             $path = $urlParts['path'] ?? null;
@@ -64,10 +70,10 @@ class VideoEmbed
             $firstSegment = $segments[1] ?? null;
 
             if ($firstSegment === null) return null;
-            
+
             return '//player.vimeo.com/video/' . $firstSegment . '?player_id=video&api=1';
         }
-    
+
         return null;
     }
 


### PR DESCRIPTION
I had the need to load YouTube video thumbnails in my templates. 

This PR adds a new service method that returns more video metadata that our current `VideoEmbed::getEmbedUrl()`

Calling `craft.videoEmbed.getVideoData('https://www.youtube.com/watch?=X9tg3J5OiYU')` will return a Model with the following data.

```php
object(viget\videoembed\models\VideoData)#1543 (5) {
  ["type"]=>
  string(7) "youtube"
  ["id"]=>
  string(11) "X9tg3J5OiYU"
  ["image"]=>
  string(48) "https://i.ytimg.com/vi/X9tg3J5OiYU/hqdefault.jpg"
  ["embedUrl"]=>
  string(41) "https://www.youtube.com/embed/X9tg3J5OiYU"
  ["url"]=>
  string(42) "https://www.youtube.com/watch?=X9tg3J5OiYU"
}
```