### PR TITLE
[#12] Parse shortened YouTube URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.3 - 2024-04-01
+### Added
+- Expand getYouTubeIdFromUrl to allow shortened YouTube URLs
+
 ## 2.0.0 - 2022-09-07
 ### Added
 - Updated for Craft 4

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generate an embed URL from a YouTube or Vimeo URL.
 
 ## Requirements
 
-This plugin requires Craft CMS 4.0.0-beta or later.
+This plugin requires Craft CMS 4.0.0 or later.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "viget/craft-video-embed",
     "description": "Generate an embed URL from a YouTube or Vimeo URL",
     "type": "craft-plugin",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "keywords": [
         "craft",
         "cms",
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^4.0.0-alpha"
+        "craftcms/cms": "^4.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/helpers/ParsingHelper.php
+++ b/src/helpers/ParsingHelper.php
@@ -60,15 +60,21 @@ class ParsingHelper
         
         if ($query) {
             parse_str($query, $qs);
-            return $qs['v'] ?? $qs['vi'] ?? null;
+            if ($qs['v'] || $qs['vi']) {
+                return $qs['v'] ?? $qs['vi'];
+            }
         }
-    
-        // Deals with https://youtu.be/X9tg3J5OiYU URLs
+
+        /**
+         * Patterns:
+         * - https://www.youtube.com/watch?v=--HXLM8GuxA
+         * - https://youtu.be/--HXLM8GuxA?si=pNahKJLszKr8J00u
+         */
         if ($path) {
             $explodedPath = explode('/', trim($path, '/'));
             return $explodedPath[0] ?? null;
         }
-        
+
         return null;
     }
     


### PR DESCRIPTION
## Ticket

- #12 

## Addresses

- Expands `getYouTubeIdFromUrl()` to parse shortened URLs like `https://youtu.be/--HXLM8GuxA?si=pNahKJLszKr8J00u` while still handling standard URLs like `https://www.youtube.com/watch?v=--HXLM8GuxA`
- Updates version to 2.0.3

## Questions

Are there other steps needed to prepare a release?