### PR TITLE
fix vimeo video’s with hash not generating a valid embedUrl

### DIFF
--- a/src/helpers/ParsingHelper.php
+++ b/src/helpers/ParsingHelper.php
@@ -8,7 +8,7 @@ use viget\videoembed\models\VideoData;
 class ParsingHelper
 {
     const YOUTUBE_URLS = ['youtube.com', 'youtu.be'];
-    const VIMEO_URLS = ['vimeo.com'];
+    const VIMEO_URLS = ['vimeo.com', 'player.vimeo.com'];
     
     public static function getVideoDataFromUrl(string $url): ?VideoData
     {
@@ -17,7 +17,8 @@ class ParsingHelper
                 self::getYouTubeIdFromUrl($url)
             ),
             VideoType::VIMEO => VideoData::forVimeo(
-                self::getVimeoIdFromUrl($url)
+                self::getVimeoIdFromUrl($url),
+                self::getVimeoHashFromUrl($url)
             ),
             default => null,
         };
@@ -83,20 +84,59 @@ class ParsingHelper
     }
     
     /**
-     * Gets the video id from a Vimeo URL
+     * Gets the video id from a Vimeo URL.
+     * Handles both vimeo.com/{id} and player.vimeo.com/video/{id} formats.
      */
     public static function getVimeoIdFromUrl(string $url): ?string
     {
         $parts = parse_url($url);
         $path = $parts['path'] ?? null;
-        
+
         if (!$path) {
             return null;
         }
-        
+
         $segments = explode('/', trim($path, '/'));
-    
+
+        // player.vimeo.com paths are /video/{id} — skip the leading 'video' segment
+        if (($segments[0] ?? null) === 'video') {
+            return $segments[1] ?? null;
+        }
+
         return $segments[0] ?? null;
+    }
+
+    /**
+     * Gets the private hash from a Vimeo URL.
+     * Handles vimeo.com/{id}/{hash} and player.vimeo.com/video/{id}?h={hash} formats.
+     */
+    public static function getVimeoHashFromUrl(string $url): ?string
+    {
+        $parts = parse_url($url);
+
+        // player.vimeo.com uses ?h= query param
+        if (isset($parts['query'])) {
+            parse_str($parts['query'], $qs);
+            if (!empty($qs['h'])) {
+                return $qs['h'];
+            }
+        }
+
+        $path = $parts['path'] ?? null;
+
+        if (!$path) {
+            return null;
+        }
+
+        $segments = explode('/', trim($path, '/'));
+
+        // vimeo.com/{id}/{hash} — hash is the second segment
+        // skip if first segment is 'video' (player URL with no hash in path)
+        if (($segments[0] ?? null) === 'video') {
+            return null;
+        }
+
+        return $segments[1] ?? null;
     }
 
 }

--- a/src/models/VideoData.php
+++ b/src/models/VideoData.php
@@ -31,18 +31,26 @@ class VideoData
         );
     }
     
-    public static function forVimeo(?string $vimeoId): ?static
+    public static function forVimeo(?string $vimeoId, ?string $vimeoHash = null): ?static
     {
         if (!$vimeoId) {
             return null;
         }
-        
+
+        $embedUrl = "https://player.vimeo.com/video/{$vimeoId}";
+        $canonicalUrl = "https://www.vimeo.com/{$vimeoId}";
+
+        if ($vimeoHash) {
+            $embedUrl .= "?h={$vimeoHash}";
+            $canonicalUrl .= "/{$vimeoHash}";
+        }
+
         return new self(
             type: VideoType::VIMEO->value,
             id: $vimeoId,
             image: null, // TODO there isn't an easy way to get this without querying an API or oEmbed endpoint
-            embedUrl: "https://player.vimeo.com/video/{$vimeoId}",
-            url: "https://www.vimeo.com/{$vimeoId}",
+            embedUrl: $embedUrl,
+            url: $canonicalUrl,
         );
     }
 }

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -36,4 +36,71 @@ final class ParsingHelperTest extends TestCase
             ParsingHelper::getYouTubeIdFromUrl('https://youtube.com/watch?v=--HXLM8GuxA')
         );
     }
+
+    public function testGetVimeoIdFromUrl(): void
+    {
+        $this->assertEquals(
+            '9999999999',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/9999999999')
+        );
+
+        $this->assertEquals(
+            '9999999999',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/9999999999/0000000000')
+        );
+
+        $this->assertEquals(
+            '9999999999',
+            ParsingHelper::getVimeoIdFromUrl('https://player.vimeo.com/video/9999999999')
+        );
+
+        $this->assertEquals(
+            '9999999999',
+            ParsingHelper::getVimeoIdFromUrl('https://player.vimeo.com/video/9999999999?h=0000000000')
+        );
+    }
+
+    public function testGetVimeoHashFromUrl(): void
+    {
+        $this->assertNull(
+            ParsingHelper::getVimeoHashFromUrl('https://vimeo.com/9999999999')
+        );
+
+        $this->assertEquals(
+            '0000000000',
+            ParsingHelper::getVimeoHashFromUrl('https://vimeo.com/9999999999/0000000000')
+        );
+
+        $this->assertNull(
+            ParsingHelper::getVimeoHashFromUrl('https://player.vimeo.com/video/9999999999')
+        );
+
+        $this->assertEquals(
+            '0000000000',
+            ParsingHelper::getVimeoHashFromUrl('https://player.vimeo.com/video/9999999999?h=0000000000')
+        );
+    }
+
+    public function testGetVimeoEmbedUrl(): void
+    {
+        $this->assertEquals(
+            'https://player.vimeo.com/video/9999999999',
+            ParsingHelper::getVideoDataFromUrl('https://vimeo.com/9999999999')->embedUrl
+        );
+
+        $this->assertEquals(
+            'https://player.vimeo.com/video/9999999999?h=0000000000',
+            ParsingHelper::getVideoDataFromUrl('https://vimeo.com/9999999999/0000000000')->embedUrl
+        );
+
+        $this->assertEquals(
+            'https://player.vimeo.com/video/9999999999',
+            ParsingHelper::getVideoDataFromUrl('https://player.vimeo.com/video/9999999999')->embedUrl
+        );
+
+        $this->assertEquals(
+            'https://player.vimeo.com/video/9999999999?h=0000000000',
+            ParsingHelper::getVideoDataFromUrl('https://player.vimeo.com/video/9999999999?h=0000000000')->embedUrl
+        );
+    }
 }


### PR DESCRIPTION
This fixes #23 for the v3 branch. 
Tests included.