### PR TITLE
Fix malformed YouTube canonical URL (missing v in ?v=)

### DIFF
--- a/src/models/VideoData.php
+++ b/src/models/VideoData.php
@@ -27,7 +27,7 @@ class VideoData
             id: $youtubeId,
             image: "https://i.ytimg.com/vi/{$youtubeId}/hqdefault.jpg",
             embedUrl: "https://www.youtube.com/embed/{$youtubeId}",
-            url: "https://www.youtube.com/watch?={$youtubeId}",
+            url: "https://www.youtube.com/watch?v={$youtubeId}",
         );
     }
     

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -81,6 +81,29 @@ final class ParsingHelperTest extends TestCase
         );
     }
 
+    public function testGetYouTubeCanonicalUrl(): void
+    {
+        $this->assertEquals(
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            ParsingHelper::getVideoDataFromUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')->url
+        );
+
+        $this->assertEquals(
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            ParsingHelper::getVideoDataFromUrl('https://youtu.be/dQw4w9WgXcQ')->url
+        );
+
+        $this->assertEquals(
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            ParsingHelper::getVideoDataFromUrl('https://youtu.be/dQw4w9WgXcQ?si=abc123')->url
+        );
+
+        $this->assertEquals(
+            'https://www.youtube.com/watch?v=--HXLM8GuxA',
+            ParsingHelper::getVideoDataFromUrl('https://youtube.com/watch?v=--HXLM8GuxA')->url
+        );
+    }
+
     public function testGetVimeoEmbedUrl(): void
     {
         $this->assertEquals(


### PR DESCRIPTION
## Summary
- Fix typo in `VideoData::forYoutube` that produced `https://www.youtube.com/watch?={id}` instead of `?v={id}`, breaking "open in YouTube" / canonical-link use cases. Embeds were unaffected.
- Add `testGetYouTubeCanonicalUrl` covering watch URLs, `youtu.be` short URLs (with and without `si=`), and IDs starting with `--`.

Refs #26.

## Test plan
- [x] `composer phpunit` — 6 tests, 21 assertions, all pass
- [x] New test fails on `v3` before the one-line fix in `src/models/VideoData.php:30`