### PR TITLE
Fix malformed YouTube canonical URL (missing v in ?v=)

### DIFF
--- a/src/models/VideoData.php
+++ b/src/models/VideoData.php
@@ -27,7 +27,7 @@ class VideoData
             id: $youtubeId,
             image: "https://i.ytimg.com/vi/{$youtubeId}/hqdefault.jpg",
             embedUrl: "https://www.youtube.com/embed/{$youtubeId}",
-            url: "https://www.youtube.com/watch?={$youtubeId}",
+            url: "https://www.youtube.com/watch?v={$youtubeId}",
         );
     }
     

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -58,6 +58,29 @@ final class ParsingHelperTest extends TestCase
         );
     }
 
+    public function testGetYouTubeCanonicalUrl(): void
+    {
+        $this->assertEquals(
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            ParsingHelper::getVideoDataFromUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')->url
+        );
+
+        $this->assertEquals(
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            ParsingHelper::getVideoDataFromUrl('https://youtu.be/dQw4w9WgXcQ')->url
+        );
+
+        $this->assertEquals(
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            ParsingHelper::getVideoDataFromUrl('https://youtu.be/dQw4w9WgXcQ?si=abc123')->url
+        );
+
+        $this->assertEquals(
+            'https://www.youtube.com/watch?v=--HXLM8GuxA',
+            ParsingHelper::getVideoDataFromUrl('https://youtube.com/watch?v=--HXLM8GuxA')->url
+        );
+    }
+
     public function testGetVimeoEmbedUrl(): void
     {
         $this->assertEquals(


### PR DESCRIPTION
v2 paired fix for #28 (v3).

## Summary
- Fix typo in `VideoData::forYoutube` that produced `https://www.youtube.com/watch?={id}` instead of `?v={id}`, breaking "open in YouTube" / canonical-link use cases. Embeds were unaffected.
- Add `testGetYouTubeCanonicalUrl` covering watch URLs, `youtu.be` short URLs (with and without `si=`), and IDs starting with `--`.

Refs #26.

## Test plan
- [x] `composer phpunit` — 5 tests, 17 assertions, all pass
- [x] New test fails on `v2` before the one-line fix in `src/models/VideoData.php:30`

## Note
The new test surfaces 2 pre-existing PHP warnings on `v2` (`Undefined array key "v"`/`"vi"` in `src/helpers/ParsingHelper.php:64`) when parsing `youtu.be/...` URLs. These are out of scope here; they are already fixed on `v3` in `44d57c4` ([#18]). PHPUnit still exits 0 — the suite passes.