### PR TITLE
[#27] CI: run PHPUnit on every pull request (v3)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,10 @@ jobs:
   phpunit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
           coverage: none
-      - uses: ramsey/composer-install@v3
+      - uses: ramsey/composer-install@v4
       - run: composer phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: tests
+
+on:
+  pull_request:
+    branches: [v3]
+  push:
+    branches: [v3]
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+      - uses: ramsey/composer-install@v3
+      - run: composer phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,5 +15,5 @@ jobs:
         with:
           php-version: '8.3'
           coverage: none
-      - uses: ramsey/composer-install@v4
+      - uses: ramsey/composer-install@4.0.0
       - run: composer phpunit


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/tests.yml` running PHPUnit on PHP 8.3
- Triggers on `pull_request` targeting `v3` and `push` to `v3`
- Uses `shivammathur/setup-php` and `ramsey/composer-install`, then runs `composer phpunit`

Refs #27.

## Test plan

- [ ] Workflow appears in the Actions tab once pushed
- [ ] `phpunit` job runs and passes on this PR
- [ ] After merge, configure the `phpunit` job as a required check on the `v3` branch protection rule