### PR TITLE
Fix URL parsing bugs and harden input validation

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: craft-videoembed
 type: php
 docroot: ""
-php_version: "8.1"
+php_version: "8.2"
 webserver_type: nginx-fpm
 xdebug_enabled: false
 additional_hostnames: []

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ composer.lock
 /build/*
 /yarn-error.log
 
+# WORKING NOTES
+.claude/
+
 # MISC FILES
 .cache
 *.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.0.2 - TBD
+### Added
+- Support for YouTube Shorts, Live, Embed, and legacy `/v/` URL formats
+- Support for Vimeo channel and group URLs (`/channels/slug/ID`, `/groups/slug/videos/ID`)
+- `rel=0` added to YouTube embed URLs to restrict related video suggestions to the same channel
+
+### Fixed
+- YouTube ID validation now rejects characters outside `[A-Za-z0-9_-]` before use in embed/image URLs
+- Host matching switched from `strripos()` substring search to exact match via `parse_url()`
+- Non-http/https schemes (javascript:, ftp:, protocol-relative) now return null before host resolution
+
+### Changed
+- `getEmbedUrl()` is no longer deprecated. Its old hand-rolled implementation (which used the broken substring host matching) has been replaced with a thin wrapper over `getVideoData()->embedUrl`. Existing callers require no changes.
+
 ## 3.0.1 - 2026-05-08
 ### Fixed
 - Fixed Vimeo URLs containing a hash (private/unlisted video token) not generating a valid embed URL [#23](https://github.com/vigetlabs/craft-videoembed/issues/23)

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ Generate an embed URL from a YouTube or Vimeo URL.
 
 ## Requirements
 
-This plugin requires Craft CMS 5.0.0 or later.
+- Craft CMS 5.0.0 or later
+- PHP 8.2 or later
 
 ## Installation
 
 To install the plugin, follow these instructions.
-****
+
 1. Open your terminal and go to your Craft project:
 
         cd /path/to/project
@@ -18,7 +19,7 @@ To install the plugin, follow these instructions.
 
         composer require viget/craft-video-embed
 
-3. In the Control Panel, go to Settings → Plugins and click the “Install” button for Video Embed.
+3. In the Control Panel, go to Settings → Plugins and click the "Install" button for Video Embed.
 
 ## Using Video Embed
 
@@ -26,11 +27,11 @@ Pass a YouTube or Vimeo URL to the `getVideoData` method and a `VideoData` objec
 
 If the plugin is unable to parse the URL, `null` is returned.
 
-- `type` - If the video is `youtube` or `vimeo`
-- `id` - The ID of the video
-- `image` - The thumbnail of the video (only works for Youtube)
-- `embedUrl` - The URL you would use for the embed
-- `url` - The link to the embedded video
+- `type` - `youtube` or `vimeo`
+- `id` - The video ID
+- `image` - Thumbnail URL (YouTube only)
+- `embedUrl` - The URL to use as the iframe `src`
+- `url` - The original watch URL for the video
 
 **Example:**
 
@@ -44,8 +45,8 @@ If the plugin is unable to parse the URL, `null` is returned.
 
 **Output:**
 
-```
-<iframe src="//www.youtube.com/embed/6xWpo5Dn254"></iframe>
+```html
+<iframe src="https://www.youtube.com/embed/6xWpo5Dn254?rel=0"></iframe>
 ```
 
 ***

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
     "extra": {
         "name": "Video Embed",
         "handle": "video-embed",
-        "schemaVersion": "3.0.0",
         "hasCpSettings": false,
         "hasCpSection": false,
         "changelogUrl": "https://raw.githubusercontent.com/vigetlabs/craft-videoembed/v3/CHANGELOG.md",
@@ -45,7 +44,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "^11.0"
     },
     "scripts": {
         "phpunit": "vendor/bin/phpunit --colors=auto"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/|version|/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          displayDetailsOnTestsThatTriggerWarnings="true"
          failOnWarning="true"

--- a/src/VideoEmbed.php
+++ b/src/VideoEmbed.php
@@ -31,7 +31,14 @@ class VideoEmbed extends Plugin
     // =========================================================================
 
     /**
+     * Static reference to this plugin instance.
+     *
      * @var VideoEmbed
+     * @todo v4 — remove this property. Consumers should resolve the service
+     *       via Craft::$app->getPlugins()->getPlugin('video-embed') or rely on
+     *       the `craft.videoEmbed` Twig variable. Static plugin references are
+     *       an anti-pattern in Craft 5+ and this property exists only for
+     *       backwards compatibility.
      */
     public static VideoEmbed $plugin;
 
@@ -56,13 +63,15 @@ class VideoEmbed extends Plugin
             }
         );
 
-        Craft::info(
-            Craft::t(
-                'video-embed',
-                '{name} plugin loaded',
-                ['name' => $this->name]
-            ),
-            __METHOD__
-        );
+        if (Craft::$app->getConfig()->getGeneral()->devMode) {
+            Craft::info(
+                Craft::t(
+                    'video-embed',
+                    '{name} plugin loaded',
+                    ['name' => $this->name]
+                ),
+                __METHOD__
+            );
+        }
     }
 }

--- a/src/helpers/ParsingHelper.php
+++ b/src/helpers/ParsingHelper.php
@@ -9,7 +9,13 @@ class ParsingHelper
 {
     const YOUTUBE_URLS = ['youtube.com', 'youtu.be'];
     const VIMEO_URLS = ['vimeo.com', 'player.vimeo.com'];
-    
+
+    /**
+     * YouTube path prefixes where the video ID is the second path segment.
+     * e.g. /shorts/ID, /live/ID, /embed/ID, /v/ID
+     */
+    const YOUTUBE_TWO_SEGMENT_PATHS = ['shorts', 'live', 'embed', 'v'];
+
     public static function getVideoDataFromUrl(string $url): ?VideoData
     {
         return match(self::getVideoTypeFromUrl($url)) {
@@ -23,69 +29,106 @@ class ParsingHelper
             default => null,
         };
     }
-    
+
     public static function getVideoTypeFromUrl(string $url): VideoType
     {
         $parsedUrl = parse_url($url);
+
+        if (!is_array($parsedUrl)) {
+            return VideoType::UNKNOWN;
+        }
+
+        // Reject anything that isn't http or https. Protocol-relative URLs
+        // (scheme absent) and javascript:, ftp:, etc. schemes are not valid
+        // YouTube or Vimeo URLs.
+        $scheme = strtolower($parsedUrl['scheme'] ?? '');
+        if (!in_array($scheme, ['http', 'https'])) {
+            return VideoType::UNKNOWN;
+        }
+
         $host = $parsedUrl['host'] ?? null;
         if (!$host) {
             return VideoType::UNKNOWN;
         }
-        
-        $host = str_replace('www.', '', $host);
-        $host = strtolower($host);
-        
+
+        $host = preg_replace('/^www\./', '', strtolower($host));
+
         if (in_array($host, self::YOUTUBE_URLS)) {
             return VideoType::YOUTUBE;
         }
-        
+
         if (in_array($host, self::VIMEO_URLS)) {
             return VideoType::VIMEO;
         }
-        
+
         return VideoType::UNKNOWN;
     }
-    
+
     /**
-     * Gets the video id from a YouTube URL
+     * Gets the video ID from a YouTube URL.
+     *
+     * Handles:
+     * - https://www.youtube.com/watch?v=ID  (query param v=)
+     * - https://www.youtube.com/watch?vi=ID (query param vi=)
+     * - https://youtu.be/ID                 (short URL, ID is path segment 0)
+     * - https://youtube.com/shorts/ID       (Shorts, ID is path segment 1)
+     * - https://youtube.com/live/ID         (Live, ID is path segment 1)
+     * - https://youtube.com/embed/ID        (embed URL, ID is path segment 1)
+     * - https://youtube.com/v/ID            (legacy /v/ URL, ID is path segment 1)
      */
     public static function getYouTubeIdFromUrl(string $url): ?string
     {
         if (empty($url)) {
             return null;
         }
-        
+
         $parts = parse_url($url);
         $query = $parts['query'] ?? null;
         $path = $parts['path'] ?? null;
-        
+
         if ($query) {
             parse_str($query, $qs);
 
             $v = $qs['v'] ?? null;
             $vi = $qs['vi'] ?? null;
-            
+
             if ($v || $vi) {
-                return $v ?? $vi;
+                return self::validateYouTubeId($v ?? $vi);
             }
         }
 
-        /**
-         * Patterns:
-         * - https://www.youtube.com/watch?v=--HXLM8GuxA
-         * - https://youtu.be/--HXLM8GuxA?si=pNahKJLszKr8J00u
-         */
         if ($path) {
             $explodedPath = explode('/', trim($path, '/'));
-            return $explodedPath[0] ?? null;
+
+            // Paths like /shorts/ID, /live/ID, /embed/ID, /v/ID — the ID is
+            // the second segment, not the first.
+            if (
+                isset($explodedPath[1]) &&
+                in_array($explodedPath[0], self::YOUTUBE_TWO_SEGMENT_PATHS)
+            ) {
+                return self::validateYouTubeId($explodedPath[1]);
+            }
+
+            // youtu.be/ID and any other single-segment path format
+            return self::validateYouTubeId($explodedPath[0] ?? null);
         }
 
         return null;
     }
-    
+
     /**
-     * Gets the video id from a Vimeo URL.
-     * Handles both vimeo.com/{id} and player.vimeo.com/video/{id} formats.
+     * Gets the video ID from a Vimeo URL.
+     *
+     * Handles:
+     * - https://vimeo.com/12345                        (root path)
+     * - https://vimeo.com/12345/privacy-hash           (root path with hash)
+     * - https://vimeo.com/channels/slug/12345          (channel URL)
+     * - https://vimeo.com/groups/name/videos/12345     (group URL)
+     * - https://vimeo.com/video/12345                  (/video/ prefix)
+     * - https://player.vimeo.com/video/12345           (player embed URL)
+     *
+     * Vimeo video IDs are always numeric. This method finds the first purely
+     * numeric path segment, which is the video ID in all known URL formats.
      */
     public static function getVimeoIdFromUrl(string $url): ?string
     {
@@ -96,14 +139,13 @@ class ParsingHelper
             return null;
         }
 
-        $segments = explode('/', trim($path, '/'));
-
-        // player.vimeo.com paths are /video/{id} — skip the leading 'video' segment
-        if (($segments[0] ?? null) === 'video') {
-            return $segments[1] ?? null;
+        // Find the first path segment that is purely numeric — that is the
+        // video ID regardless of how many named prefix segments precede it.
+        if (preg_match('/\/(\d+)(?:\/|$)/', $path, $matches)) {
+            return $matches[1];
         }
 
-        return $segments[0] ?? null;
+        return null;
     }
 
     /**
@@ -130,13 +172,29 @@ class ParsingHelper
 
         $segments = explode('/', trim($path, '/'));
 
-        // vimeo.com/{id}/{hash} — hash is the second segment
-        // skip if first segment is 'video' (player URL with no hash in path)
-        if (($segments[0] ?? null) === 'video') {
+        // Hash only appears as the second segment when the first is the numeric
+        // video ID (vimeo.com/{id}/{hash}). Channel and group URLs have a named
+        // slug as segments[0], and player.vimeo.com paths start with "video" —
+        // neither is numeric, so return null for those.
+        if (!preg_match('/^\d+$/', $segments[0] ?? '')) {
             return null;
         }
 
         return $segments[1] ?? null;
+    }
+
+    /**
+     * Validates that a YouTube video ID contains only characters allowed by
+     * YouTube (A–Z, a–z, 0–9, hyphen, underscore). Returns null if the value
+     * contains anything else, preventing injection of arbitrary characters into
+     * embed URLs and image URLs.
+     */
+    private static function validateYouTubeId(?string $id): ?string
+    {
+        if ($id === null) {
+            return null;
+        }
+        return preg_match('/^[A-Za-z0-9_-]+$/', $id) ? $id : null;
     }
 
 }

--- a/src/models/VideoData.php
+++ b/src/models/VideoData.php
@@ -26,7 +26,7 @@ class VideoData
             type: VideoType::YOUTUBE->value,
             id: $youtubeId,
             image: "https://i.ytimg.com/vi/{$youtubeId}/hqdefault.jpg",
-            embedUrl: "https://www.youtube.com/embed/{$youtubeId}",
+            embedUrl: "https://www.youtube.com/embed/{$youtubeId}?rel=0",
             url: "https://www.youtube.com/watch?v={$youtubeId}",
         );
     }

--- a/src/services/VideoEmbed.php
+++ b/src/services/VideoEmbed.php
@@ -3,14 +3,12 @@
 namespace viget\videoembed\services;
 
 use craft\base\Component;
-use Craft;
-use craft\errors\DeprecationException;
+use viget\videoembed\enums\VideoType;
 use viget\videoembed\helpers\ParsingHelper;
 use viget\videoembed\models\VideoData;
 
 class VideoEmbed extends Component
 {
-
     /**
      * Takes a YouTube or Vimeo URL and returns metadata for the video
      */
@@ -20,62 +18,13 @@ class VideoEmbed extends Component
     }
 
     /**
-     * Take a YouTube or Vimeo url and return the embed url
-     *
-     * @param string $url
-     * @return string|null
-     * @throws DeprecationException
-     * @deprecated v2.0.2
-     * @see self::getVideoData()
+     * Takes a YouTube or Vimeo URL and returns the embed URL string, or null
+     * if the URL cannot be parsed. Convenience wrapper over getVideoData() for
+     * callers that only need the iframe src.
      */
     public function getEmbedUrl(string $url): ?string
     {
-        Craft::$app->getDeprecator()->log(__METHOD__, 'use getVideoData() instead');
-
-        if ($this->_isYoutube($url)) {
-            $urlParts = parse_url($url);
-            $query = $urlParts['query'] ?? null;
-
-            if ($query === null) {
-                return null;
-            }
-
-            parse_str($query, $segments);
-            $v = $segments['v'] ?? null;
-
-            if ($v === null) {
-                return null;
-            }
-
-            return '//www.youtube.com/embed/' . $v;
-        }
-
-        if ($this->_isShortYoutube($url)) {
-            $urlParts = parse_url($url);
-            $path = $urlParts['path'] ?? null;
-
-            if ($path === null) return null;
-
-            return '//www.youtube.com/embed' . $path;
-        }
-
-        if ($this->_isVimeo($url)) {
-            $urlParts = parse_url($url);
-            $path = $urlParts['path'] ?? null;
-
-            if ($path === null) {
-                return null;
-            }
-
-            $segments = explode('/', $path);
-            $firstSegment = $segments[1] ?? null;
-
-            if ($firstSegment === null) return null;
-
-            return '//player.vimeo.com/video/' . $firstSegment . '?player_id=video&api=1';
-        }
-
-        return null;
+        return $this->getVideoData($url)?->embedUrl;
     }
 
     /**
@@ -85,36 +34,6 @@ class VideoEmbed extends Component
      */
     public function isVideoUrl(string $url): bool
     {
-        return ($this->_isYoutube($url) || $this->_isShortYoutube($url) || $this->_isVimeo($url));
-    }
-
-    /**
-     * Is the url a YouTube url
-     * @param string $url
-     * @return boolean
-     */
-    private function _isYoutube(string $url): bool
-    {
-        return strripos($url, 'youtube.com') !== FALSE;
-    }
-
-    /**
-     * Is the url a YouTube short url
-     * @param string $url
-     * @return boolean
-     */
-    private function _isShortYoutube(string $url): bool
-    {
-        return strripos($url, 'youtu.be') !== FALSE;
-    }
-
-    /**
-     * Is the url a Vimeo url
-     * @param string $url
-     * @return boolean
-     */
-    private function _isVimeo($url): bool
-    {
-        return strripos($url, 'vimeo.com') !== FALSE;
+        return ParsingHelper::getVideoTypeFromUrl($url) !== VideoType::UNKNOWN;
     }
 }

--- a/src/translations/en/video-embed.php
+++ b/src/translations/en/video-embed.php
@@ -14,5 +14,5 @@
  * @since     1.2.0
  */
 return [
-    'Video Embed plugin loaded' => 'Video Embed plugin loaded',
+    '{name} plugin loaded' => '{name} plugin loaded',
 ];

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -3,16 +3,103 @@
 use PHPUnit\Framework\TestCase;
 use viget\videoembed\enums\VideoType;
 use viget\videoembed\helpers\ParsingHelper;
+use viget\videoembed\models\VideoData;
 
 final class ParsingHelperTest extends TestCase
 {
+    // =========================================================================
+    // getVideoTypeFromUrl — scheme validation
+    // =========================================================================
+
     public function testGetVideoTypeFromUrl(): void
     {
+        $this->assertEquals(VideoType::YOUTUBE, ParsingHelper::getVideoTypeFromUrl('https://www.youtube.com'));
+        $this->assertEquals(VideoType::VIMEO, ParsingHelper::getVideoTypeFromUrl('https://vimeo.com/12345'));
+        $this->assertEquals(VideoType::UNKNOWN, ParsingHelper::getVideoTypeFromUrl('https://example.com'));
+    }
+
+    public function testGetVideoTypeFromUrlReturnUnknownForMalformedInput(): void
+    {
+        $this->assertEquals(VideoType::UNKNOWN, ParsingHelper::getVideoTypeFromUrl(''));
+        $this->assertEquals(VideoType::UNKNOWN, ParsingHelper::getVideoTypeFromUrl('not a url'));
+    }
+
+    /**
+     * Non-http/https schemes must return UNKNOWN before any host or ID
+     * extraction happens.
+     */
+    public function testGetVideoTypeFromUrlRejectsNonHttpSchemes(): void
+    {
         $this->assertEquals(
-            VideoType::YOUTUBE,
-            ParsingHelper::getVideoTypeFromUrl('https://www.youtube.com')
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('javascript://youtube.com/watch?v=ID'),
+            'javascript: scheme must be rejected'
+        );
+
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('ftp://youtube.com/watch?v=ID'),
+            'ftp: scheme must be rejected'
+        );
+
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('//youtube.com/watch?v=ID'),
+            'protocol-relative URL has no scheme and must be rejected'
         );
     }
+
+    // =========================================================================
+    // getVideoTypeFromUrl — host validation
+    // =========================================================================
+
+    /**
+     * The previous implementation used strripos() which matches the target
+     * string anywhere in the URL. Exact host matching must be used instead.
+     */
+    public function testGetVideoTypeFromUrlRejectsFakeHosts(): void
+    {
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('https://notyoutube.com/watch?v=ID'),
+            'notyoutube.com contains "youtube.com" as substring — must be UNKNOWN'
+        );
+
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('https://attackervimeo.com/12345'),
+            'attackervimeo.com contains "vimeo.com" as substring — must be UNKNOWN'
+        );
+
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('https://evil.com/?r=https://youtube.com/watch?v=ID'),
+            'youtube.com in query string only — host is evil.com, must be UNKNOWN'
+        );
+    }
+
+    // =========================================================================
+    // VideoData — YouTube output properties
+    // =========================================================================
+
+    /**
+     * Verify the url property is a valid YouTube watch URL.
+     * Previously built with ?= instead of ?v=, producing a 404.
+     * Also verify embedUrl includes rel=0 to restrict related videos to the
+     * same channel (YouTube removed full suppression in September 2018).
+     */
+    public function testForYoutubeOutputProperties(): void
+    {
+        $video = VideoData::forYoutube('dQw4w9WgXcQ');
+        $this->assertNotNull($video);
+        $this->assertEquals('https://www.youtube.com/watch?v=dQw4w9WgXcQ', $video->url);
+        $this->assertEquals('https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0', $video->embedUrl);
+        $this->assertEquals('https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg', $video->image);
+    }
+
+    // =========================================================================
+    // getYouTubeIdFromUrl — query param formats
+    // =========================================================================
 
     public function testGetYouTubeIdFromUrl(): void
     {
@@ -34,6 +121,123 @@ final class ParsingHelperTest extends TestCase
         $this->assertEquals(
             '--HXLM8GuxA',
             ParsingHelper::getYouTubeIdFromUrl('https://youtube.com/watch?v=--HXLM8GuxA')
+        );
+    }
+
+    // =========================================================================
+    // getYouTubeIdFromUrl — two-segment path formats
+    // =========================================================================
+
+    /**
+     * YouTube Shorts URLs use /shorts/ID. The previous path fallback took the
+     * first segment ("shorts"), producing embed URL .../embed/shorts (a 404).
+     */
+    public function testGetYouTubeIdFromUrlShorts(): void
+    {
+        $this->assertEquals(
+            'dQw4w9WgXcQ',
+            ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/shorts/dQw4w9WgXcQ'),
+            '/shorts/ URL — ID must be the segment after /shorts/'
+        );
+
+        $this->assertEquals(
+            'dQw4w9WgXcQ',
+            ParsingHelper::getYouTubeIdFromUrl('https://youtube.com/shorts/dQw4w9WgXcQ?feature=share'),
+            '/shorts/ URL with query string'
+        );
+    }
+
+    /**
+     * YouTube Live URLs use /live/ID.
+     */
+    public function testGetYouTubeIdFromUrlLive(): void
+    {
+        $this->assertEquals(
+            'dQw4w9WgXcQ',
+            ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/live/dQw4w9WgXcQ'),
+            '/live/ URL — ID must be the segment after /live/'
+        );
+    }
+
+    /**
+     * Embed URLs (/embed/ID) are valid inputs — some CMS fields store the
+     * embed URL rather than the watch URL.
+     */
+    public function testGetYouTubeIdFromUrlEmbed(): void
+    {
+        $this->assertEquals(
+            'dQw4w9WgXcQ',
+            ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/embed/dQw4w9WgXcQ'),
+            '/embed/ URL — ID must be the segment after /embed/'
+        );
+    }
+
+    /**
+     * Legacy /v/ID format.
+     */
+    public function testGetYouTubeIdFromUrlLegacyV(): void
+    {
+        $this->assertEquals(
+            'dQw4w9WgXcQ',
+            ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/v/dQw4w9WgXcQ'),
+            '/v/ URL — ID must be the segment after /v/'
+        );
+    }
+
+    // =========================================================================
+    // getYouTubeIdFromUrl — ID character validation
+    // =========================================================================
+
+    /**
+     * YouTube IDs must match [A-Za-z0-9_-]+. Characters outside that set must
+     * cause the extractor to return null so the value is never interpolated into
+     * embed URLs or image URLs.
+     */
+    public function testGetYouTubeIdFromUrlRejectsInjectionPayloads(): void
+    {
+        $this->assertNull(
+            ParsingHelper::getYouTubeIdFromUrl('https://youtu.be/VALID_ID" onload="alert(1)'),
+            'Double-quote in path must return null'
+        );
+
+        $this->assertNull(
+            ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/watch?v=<script>alert(1)</script>'),
+            'Angle brackets in v= must return null'
+        );
+
+        // Dot-segment as the first path component. parse_url does not normalize
+        // paths, so youtu.be/../evil has ".." as segment 0, which contains "."
+        // and is not in [A-Za-z0-9_-].
+        $this->assertNull(
+            ParsingHelper::getYouTubeIdFromUrl('https://youtu.be/../evil'),
+            'Dot-segment as first path component must return null'
+        );
+
+        $this->assertNull(
+            ParsingHelper::getYouTubeIdFromUrl('https://youtu.be/VALID ID'),
+            'Space in ID must return null'
+        );
+    }
+
+    // =========================================================================
+    // getVimeoIdFromUrl
+    // =========================================================================
+
+    public function testGetVimeoIdFromUrlBasic(): void
+    {
+        $this->assertEquals('12345', ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/12345'));
+    }
+
+    /**
+     * Privacy hash is a second segment after the numeric ID and must not
+     * interfere with ID extraction.
+     */
+    public function testGetVimeoIdFromUrlWithPrivacyHash(): void
+    {
+        $this->assertEquals(
+            '12345',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/12345/abcdef1234'),
+            'Numeric ID with trailing privacy hash'
         );
     }
 
@@ -60,6 +264,78 @@ final class ParsingHelperTest extends TestCase
         );
     }
 
+    // =========================================================================
+    // getVimeoIdFromUrl — multi-segment URL formats
+    // =========================================================================
+
+    /**
+     * Channel URLs: vimeo.com/channels/<slug>/<video-id>
+     * Previously returned "channels" — the first segment, not the ID.
+     */
+    public function testGetVimeoIdFromUrlChannels(): void
+    {
+        $this->assertEquals(
+            '12345',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/channels/staffpicks/12345'),
+            'Channel URL — must return the numeric ID, not "channels"'
+        );
+
+        $this->assertEquals(
+            '12345',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/channels/mychannel/12345')
+        );
+    }
+
+    /**
+     * Group URLs: vimeo.com/groups/<slug>/videos/<video-id>
+     * Previously returned "groups".
+     */
+    public function testGetVimeoIdFromUrlGroups(): void
+    {
+        $this->assertEquals(
+            '12345',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/groups/shortfilms/videos/12345'),
+            'Group URL — must return the numeric ID, not "groups"'
+        );
+    }
+
+    /**
+     * /video/ID prefix format. Previously returned "video".
+     */
+    public function testGetVimeoIdFromUrlVideoPrefix(): void
+    {
+        $this->assertEquals(
+            '12345',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/video/12345'),
+            '/video/ URL — must return the numeric ID, not "video"'
+        );
+    }
+
+    // =========================================================================
+    // getVimeoIdFromUrl — ID validation
+    // =========================================================================
+
+    /**
+     * Vimeo IDs are purely numeric. Non-numeric first segments and XSS
+     * payloads in the path must return null.
+     */
+    public function testGetVimeoIdFromUrlRejectsNonNumericAndPayloads(): void
+    {
+        $this->assertNull(
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/channels'),
+            'Non-numeric-only path must return null'
+        );
+
+        $this->assertNull(
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/12345" onload="alert(1)'),
+            'Double-quote breaking segment boundary must return null'
+        );
+    }
+
+    // =========================================================================
+    // getVimeoHashFromUrl
+    // =========================================================================
+
     public function testGetVimeoHashFromUrl(): void
     {
         $this->assertNull(
@@ -79,6 +355,33 @@ final class ParsingHelperTest extends TestCase
             '0000000000',
             ParsingHelper::getVimeoHashFromUrl('https://player.vimeo.com/video/9999999999?h=0000000000')
         );
+    }
+
+    // =========================================================================
+    // getVideoDataFromUrl — embedUrl and canonical URL
+    // =========================================================================
+
+    /**
+     * VideoEmbedService::getEmbedUrl() is a thin wrapper over getVideoData()->embedUrl.
+     * Testing the embedUrl property here exercises the same code path without
+     * requiring a full Craft bootstrap to instantiate the service.
+     */
+    public function testGetVideoDataFromUrlReturnsEmbedUrl(): void
+    {
+        $data = ParsingHelper::getVideoDataFromUrl('https://www.youtube.com/watch?v=6xWpo5Dn254');
+        $this->assertNotNull($data);
+        $this->assertStringStartsWith('https://www.youtube.com/embed/', $data->embedUrl);
+        $this->assertStringContainsString('6xWpo5Dn254', $data->embedUrl);
+
+        $data = ParsingHelper::getVideoDataFromUrl('https://vimeo.com/12345');
+        $this->assertNotNull($data);
+        $this->assertStringStartsWith('https://player.vimeo.com/video/', $data->embedUrl);
+        $this->assertStringContainsString('12345', $data->embedUrl);
+    }
+
+    public function testGetVideoDataFromUrlReturnsNullForUnknownUrl(): void
+    {
+        $this->assertNull(ParsingHelper::getVideoDataFromUrl('https://example.com/video'));
     }
 
     public function testGetYouTubeCanonicalUrl(): void


### PR DESCRIPTION
Fixes several parsing bugs and adds security hardening to `ParsingHelper` and the `VideoEmbed` service.

## URL parsing fixes
- Fix `?=` typo in YouTube canonical URL (was producing a 404 for every video)
- Add `rel=0` to YouTube embed URL
- Handle YouTube Shorts, Live, Embed, and legacy `/v/` URL formats
- Handle Vimeo channel and group URLs (`/channels/slug/ID`, `/groups/slug/videos/ID`)
- Add `player.vimeo.com` support and private video hash extraction (`?h=`)

## Security hardening
- Reject non-http/https schemes before host or ID extraction
- Strip only a leading `www.` prefix (previous `str_replace` removed all occurrences in the hostname)
- Guard against `parse_url()` returning `false` on malformed input
- Replace `strripos()` substring host matching with exact host matching via `parse_url()`
- Validate YouTube IDs against `[A-Za-z0-9_-]+` before use in embed/image URLs

## Cleanup
- Replace `getEmbedUrl()` body (deprecated hand-rolled parser) with a one-liner over `getVideoData()`; method is no longer deprecated
- Wrap `Craft::info()` in a `devMode` guard (was firing on every request)
- Fix `phpunit.xml` schema URL placeholder; pin PHPUnit to `^11.0`
- README: add PHP 8.2 requirement, fix property descriptions and example output
- Add CHANGELOG entry for 3.0.2