### PR TITLE
Expose isVertical for YouTube Shorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ If the plugin is unable to parse the URL, `null` is returned.
 - `image` - The thumbnail of the video (only works for Youtube)
 - `embedUrl` - The URL you would use for the embed
 - `url` - The link to the embedded video
+- `isVertical` - `true` for YouTube Shorts (vertical/portrait) videos, otherwise `false`. Detected from the `/shorts/` URL form, not the video's true orientation.
 
 **Example:**
 

--- a/src/helpers/ParsingHelper.php
+++ b/src/helpers/ParsingHelper.php
@@ -9,12 +9,16 @@ class ParsingHelper
 {
     const YOUTUBE_URLS = ['youtube.com', 'youtu.be'];
     const VIMEO_URLS = ['vimeo.com', 'player.vimeo.com'];
-    
+
+    /** The YouTube path prefix that identifies a vertical Shorts video. */
+    const YOUTUBE_SHORTS_PREFIX = 'shorts';
+
     public static function getVideoDataFromUrl(string $url): ?VideoData
     {
         return match(self::getVideoTypeFromUrl($url)) {
             VideoType::YOUTUBE => VideoData::forYoutube(
-                self::getYouTubeIdFromUrl($url)
+                self::getYouTubeIdFromUrl($url),
+                self::isYouTubeShortsUrl($url)
             ),
             VideoType::VIMEO => VideoData::forVimeo(
                 self::getVimeoIdFromUrl($url),
@@ -74,13 +78,43 @@ class ParsingHelper
          * Patterns:
          * - https://www.youtube.com/watch?v=--HXLM8GuxA
          * - https://youtu.be/--HXLM8GuxA?si=pNahKJLszKr8J00u
+         * - https://www.youtube.com/shorts/--HXLM8GuxA
          */
         if ($path) {
             $explodedPath = explode('/', trim($path, '/'));
+
+            // YouTube Shorts URLs are /shorts/{id} — the ID is the second
+            // segment. Return null (not "shorts") when the ID is absent.
+            if (strtolower($explodedPath[0] ?? '') === self::YOUTUBE_SHORTS_PREFIX) {
+                return $explodedPath[1] ?? null;
+            }
+
             return $explodedPath[0] ?? null;
         }
 
         return null;
+    }
+
+    /**
+     * Determines whether a URL is a YouTube Shorts URL (path begins with
+     * /shorts/). Shorts are always vertical (portrait) videos, so this drives
+     * VideoData::$isVertical.
+     *
+     * Assumes the URL has already been identified as YouTube; it inspects only
+     * the path. Detection is based on URL form — the plugin cannot determine a
+     * video's true pixel orientation without an external API call.
+     */
+    private static function isYouTubeShortsUrl(string $url): bool
+    {
+        $path = parse_url($url, PHP_URL_PATH);
+
+        if (!$path) {
+            return false;
+        }
+
+        $segments = explode('/', trim($path, '/'));
+
+        return strtolower($segments[0] ?? '') === self::YOUTUBE_SHORTS_PREFIX;
     }
     
     /**

--- a/src/models/VideoData.php
+++ b/src/models/VideoData.php
@@ -12,25 +12,27 @@ class VideoData
         public ?string $image,
         public string $embedUrl,
         public string $url,
+        public bool $isVertical = false,
     )
     {
     }
-    
-    public static function forYoutube(?string $youtubeId): ?static
+
+    public static function forYoutube(?string $youtubeId, bool $isVertical = false): ?static
     {
         if (!$youtubeId) {
             return null;
         }
-        
+
         return new self(
             type: VideoType::YOUTUBE->value,
             id: $youtubeId,
             image: "https://i.ytimg.com/vi/{$youtubeId}/hqdefault.jpg",
             embedUrl: "https://www.youtube.com/embed/{$youtubeId}",
             url: "https://www.youtube.com/watch?v={$youtubeId}",
+            isVertical: $isVertical,
         );
     }
-    
+
     public static function forVimeo(?string $vimeoId, ?string $vimeoHash = null): ?static
     {
         if (!$vimeoId) {

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -126,4 +126,80 @@ final class ParsingHelperTest extends TestCase
             ParsingHelper::getVideoDataFromUrl('https://player.vimeo.com/video/9999999999?h=0000000000')->embedUrl
         );
     }
+
+    // =========================================================================
+    // YouTube Shorts parsing
+    // =========================================================================
+
+    public function testGetYouTubeIdFromUrlShorts(): void
+    {
+        $this->assertEquals(
+            'dQw4w9WgXcQ',
+            ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/shorts/dQw4w9WgXcQ')
+        );
+
+        $this->assertEquals(
+            'dQw4w9WgXcQ',
+            ParsingHelper::getYouTubeIdFromUrl('https://youtube.com/shorts/dQw4w9WgXcQ?feature=share')
+        );
+
+        // The /shorts/ prefix is matched case-insensitively.
+        $this->assertEquals(
+            'dQw4w9WgXcQ',
+            ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/Shorts/dQw4w9WgXcQ')
+        );
+
+        // A /shorts/ URL with no ID must return null, not the literal "shorts".
+        $this->assertNull(
+            ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/shorts')
+        );
+        $this->assertNull(
+            ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/shorts/')
+        );
+    }
+
+    // =========================================================================
+    // isVertical metadata
+    // =========================================================================
+
+    /**
+     * A YouTube Shorts URL yields a vertical VideoData while still resolving a
+     * correct ID and embed URL — the flag and parsing coexist.
+     */
+    public function testIsVerticalForShorts(): void
+    {
+        $video = ParsingHelper::getVideoDataFromUrl('https://www.youtube.com/shorts/dQw4w9WgXcQ');
+
+        $this->assertNotNull($video);
+        $this->assertTrue($video->isVertical);
+        $this->assertEquals('dQw4w9WgXcQ', $video->id);
+        $this->assertEquals('https://www.youtube.com/embed/dQw4w9WgXcQ', $video->embedUrl);
+    }
+
+    public function testIsVerticalIsFalseForNonShortsYouTube(): void
+    {
+        $this->assertFalse(
+            ParsingHelper::getVideoDataFromUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')->isVertical,
+            'watch?v= URL is not vertical'
+        );
+
+        $this->assertFalse(
+            ParsingHelper::getVideoDataFromUrl('https://youtu.be/dQw4w9WgXcQ')->isVertical,
+            'youtu.be URL is not vertical'
+        );
+    }
+
+    public function testIsVerticalIsFalseForVimeo(): void
+    {
+        $this->assertFalse(
+            ParsingHelper::getVideoDataFromUrl('https://vimeo.com/9999999999')->isVertical
+        );
+    }
+
+    public function testGetVideoDataReturnsNullForUnknownUrl(): void
+    {
+        $this->assertNull(
+            ParsingHelper::getVideoDataFromUrl('https://example.com/video')
+        );
+    }
 }


### PR DESCRIPTION
Adds an additive `isVertical` boolean to `VideoData` so consuming sites can render portrait layouts by reading a flag instead of regex-sniffing the URL.

## Changes
- `VideoData::$isVertical` (default `false`), threaded through `forYoutube()`. Twig: `video.isVertical`.
- `ParsingHelper` parses `/shorts/{id}` URLs and detects Shorts via a private `isYouTubeShortsUrl()`.
- README documents `isVertical` and that detection is URL-form based (a Shorts URL), not true pixel orientation.

## Notes
- Additive and non-breaking — existing callers that never read `isVertical` are unaffected.
- Detection is intentionally URL-based; the plugin can't know true orientation without an external API call.
- A `/shorts/` URL with no ID returns `null` (no bogus `id`).
- The `rel=0` embed change and the `embedUrlWithParams` helper were split out into #44 so this PR stays purely Shorts parsing + `isVertical`.
- Touches `getYouTubeIdFromUrl()`, which the security-hardening PR (#42) also edits — whichever merges second needs a trivial rebase.

Tests: 11 passing (PHPUnit 11).
