### PR TITLE
Fix Vimeo ID parsing for channel/group/showcase URLs (#35)

### DIFF
--- a/src/helpers/ParsingHelper.php
+++ b/src/helpers/ParsingHelper.php
@@ -92,6 +92,7 @@ class ParsingHelper
      * - vimeo.com/{id}                          (id = first segment)
      * - vimeo.com/{id}/{hash}                   (id = first segment; hash may be numeric)
      * - vimeo.com/channels/{slug}/{id}          (id = last segment)
+     * - vimeo.com/album/{slug}/{id}             (id = last segment)
      * - vimeo.com/groups/{slug}/videos/{id}     (id = segment after "videos")
      * - vimeo.com/showcase/{slug}/video/{id}    (id = segment after "video")
      * - vimeo.com/video/{id}                    (id = segment after "video")

--- a/src/helpers/ParsingHelper.php
+++ b/src/helpers/ParsingHelper.php
@@ -84,8 +84,18 @@ class ParsingHelper
     }
     
     /**
-     * Gets the video id from a Vimeo URL.
-     * Handles both vimeo.com/{id} and player.vimeo.com/video/{id} formats.
+     * Gets the numeric video ID from a Vimeo URL.
+     *
+     * The ID's position depends on the URL form, so it is located structurally
+     * rather than by grabbing the first numeric run (a numeric slug would win —
+     * see issue #35). Handles:
+     * - vimeo.com/{id}                          (id = first segment)
+     * - vimeo.com/{id}/{hash}                   (id = first segment; hash may be numeric)
+     * - vimeo.com/channels/{slug}/{id}          (id = last segment)
+     * - vimeo.com/groups/{slug}/videos/{id}     (id = segment after "videos")
+     * - vimeo.com/showcase/{slug}/video/{id}    (id = segment after "video")
+     * - vimeo.com/video/{id}                    (id = segment after "video")
+     * - player.vimeo.com/video/{id}             (id = segment after "video")
      */
     public static function getVimeoIdFromUrl(string $url): ?string
     {
@@ -96,14 +106,47 @@ class ParsingHelper
             return null;
         }
 
-        $segments = explode('/', trim($path, '/'));
+        $segments = array_values(
+            array_filter(explode('/', $path), static fn($s) => $s !== '')
+        );
 
-        // player.vimeo.com paths are /video/{id} — skip the leading 'video' segment
-        if (($segments[0] ?? null) === 'video') {
-            return $segments[1] ?? null;
+        if (!$segments) {
+            return null;
         }
 
-        return $segments[0] ?? null;
+        // /video/{id} and /groups/{slug}/videos/{id} — the ID follows the last
+        // "video"/"videos" marker.
+        $markerIndex = null;
+        foreach ($segments as $i => $segment) {
+            if ($segment === 'video' || $segment === 'videos') {
+                $markerIndex = $i;
+            }
+        }
+        if ($markerIndex !== null) {
+            return self::numericOrNull($segments[$markerIndex + 1] ?? null);
+        }
+
+        // /channels/{slug}/{id}, /showcase/{slug}/{id}, /album/{slug}/{id} —
+        // the ID is the trailing segment after the named collection.
+        if (in_array($segments[0], ['channels', 'showcase', 'album'], true)) {
+            return self::numericOrNull(end($segments));
+        }
+
+        // Root form: /{id} or /{id}/{hash} — the ID is the first segment, and a
+        // trailing hash (which may itself be numeric) is not the ID.
+        return self::numericOrNull($segments[0]);
+    }
+
+    /**
+     * Returns the value only when it is a purely-numeric string (a Vimeo video
+     * ID), otherwise null.
+     */
+    private static function numericOrNull(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+        return preg_match('/^\d+$/', $value) ? $value : null;
     }
 
     /**
@@ -130,9 +173,10 @@ class ParsingHelper
 
         $segments = explode('/', trim($path, '/'));
 
-        // vimeo.com/{id}/{hash} — hash is the second segment
-        // skip if first segment is 'video' (player URL with no hash in path)
-        if (($segments[0] ?? null) === 'video') {
+        // A path hash only appears as the second segment of vimeo.com/{id}/{hash}.
+        // Channel/group URLs lead with a named slug and player.vimeo.com paths
+        // lead with "video" — neither is numeric, so there is no path hash.
+        if (!preg_match('/^\d+$/', $segments[0] ?? '')) {
             return null;
         }
 

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -88,6 +88,12 @@ final class ParsingHelperTest extends TestCase
             ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/channels/staffpicks/12345'),
             'Channel URL — must return the numeric ID, not "channels"'
         );
+
+        $this->assertEquals(
+            '12345',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/album/myalbum/12345'),
+            'Album URL — ID is the trailing segment'
+        );
     }
 
     public function testGetVimeoIdFromUrlGroups(): void

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -81,6 +81,84 @@ final class ParsingHelperTest extends TestCase
         );
     }
 
+    public function testGetVimeoIdFromUrlChannels(): void
+    {
+        $this->assertEquals(
+            '12345',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/channels/staffpicks/12345'),
+            'Channel URL — must return the numeric ID, not "channels"'
+        );
+    }
+
+    public function testGetVimeoIdFromUrlGroups(): void
+    {
+        $this->assertEquals(
+            '12345',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/groups/shortfilms/videos/12345'),
+            'Group URL — must return the numeric ID, not "groups"'
+        );
+    }
+
+    public function testGetVimeoIdFromUrlVideoPrefix(): void
+    {
+        $this->assertEquals(
+            '12345',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/video/12345')
+        );
+    }
+
+    /**
+     * Numeric slugs must not be mistaken for the video ID (issue #35). The ID
+     * is located structurally, so a numeric channel/group/showcase slug
+     * preceding the real ID is ignored.
+     */
+    public function testGetVimeoIdFromUrlNumericSlugs(): void
+    {
+        $this->assertEquals(
+            '456',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/groups/123/videos/456'),
+            'Numeric group slug — ID is the segment after "videos"'
+        );
+
+        $this->assertEquals(
+            '12345',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/channels/2020/12345'),
+            'Numeric channel slug — ID is the trailing segment'
+        );
+
+        $this->assertEquals(
+            '12345',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/showcase/7654321/video/12345'),
+            'Numeric showcase slug — ID is the segment after "video"'
+        );
+    }
+
+    /**
+     * A numeric privacy hash in the root /{id}/{hash} form must not be returned
+     * as the ID — the ID is always the first segment here.
+     */
+    public function testGetVimeoIdFromUrlNumericHashKeepsId(): void
+    {
+        $this->assertEquals(
+            '9999999999',
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/9999999999/0000000000')
+        );
+    }
+
+    public function testGetVimeoIdFromUrlRejectsNonNumeric(): void
+    {
+        $this->assertNull(
+            ParsingHelper::getVimeoIdFromUrl('https://vimeo.com/channels')
+        );
+    }
+
+    public function testGetVimeoHashFromUrlChannelHasNoPathHash(): void
+    {
+        $this->assertNull(
+            ParsingHelper::getVimeoHashFromUrl('https://vimeo.com/channels/staffpicks/12345')
+        );
+    }
+
     public function testGetYouTubeCanonicalUrl(): void
     {
         $this->assertEquals(


### PR DESCRIPTION
Addresses #35.

The previous extractor returned the leading slug instead of the numeric video ID for channel/group URLs, and a "first numeric segment" approach silently returned a numeric slug as the ID (`vimeo.com/groups/123/videos/456` → `123`) — a confidently wrong embed, no error.

## Changes
- `getVimeoIdFromUrl()` locates the ID structurally per URL form: the segment after a `video`/`videos` marker, the trailing segment for `channels`/`showcase`/`album`, or the first segment for the root form (so a numeric privacy hash is never mistaken for the ID).
- `getVimeoHashFromUrl()` only reads a path hash when the first segment is the numeric ID.

## Tests
Adds the numeric-slug cases #35 documents, plus a numeric-hash control (`/9999999999/0000000000` → `9999999999`). 13 passing.

This also covers the **numeric-slug** test gap noted in #37. The other half of #37 — a Vimeo canonical-`url` assertion — is intentionally left out: it requires deciding the correct canonical host (`vimeo.com` vs the current `www.vimeo.com`), which is a separate change.
