### PR TITLE
Harden video URL validation; route service through ParsingHelper (#34, #36)

### DIFF
--- a/src/helpers/ParsingHelper.php
+++ b/src/helpers/ParsingHelper.php
@@ -31,46 +31,72 @@ class ParsingHelper
     public static function getVideoTypeFromUrl(string $url): VideoType
     {
         $parsedUrl = parse_url($url);
+
+        // parse_url() returns false on seriously malformed input.
+        if (!is_array($parsedUrl)) {
+            return VideoType::UNKNOWN;
+        }
+
+        // Only http/https are valid video URLs. Reject javascript:, ftp:, etc.
+        // and protocol-relative URLs (no scheme) before trusting the host.
+        $scheme = strtolower($parsedUrl['scheme'] ?? '');
+        if (!in_array($scheme, ['http', 'https'], true)) {
+            return VideoType::UNKNOWN;
+        }
+
         $host = $parsedUrl['host'] ?? null;
         if (!$host) {
             return VideoType::UNKNOWN;
         }
-        
-        $host = str_replace('www.', '', $host);
-        $host = strtolower($host);
-        
-        if (in_array($host, self::YOUTUBE_URLS)) {
+
+        // Strip a leading www. or a known YouTube subdomain (m., music.) so
+        // mobile and YouTube Music links still resolve (issue #36). Only a
+        // leading prefix is removed — a substring match would let e.g.
+        // "notyoutube.com" through.
+        $host = preg_replace('/^(www|m|music)\./', '', strtolower($host));
+
+        if (in_array($host, self::YOUTUBE_URLS, true)) {
             return VideoType::YOUTUBE;
         }
-        
-        if (in_array($host, self::VIMEO_URLS)) {
+
+        if (in_array($host, self::VIMEO_URLS, true)) {
             return VideoType::VIMEO;
         }
-        
+
         return VideoType::UNKNOWN;
     }
     
     /**
-     * Gets the video id from a YouTube URL
+     * Gets the video id from a YouTube URL.
+     *
+     * Patterns:
+     * - https://www.youtube.com/watch?v=--HXLM8GuxA
+     * - https://www.youtube.com/watch?vi=--HXLM8GuxA
+     * - https://youtu.be/--HXLM8GuxA?si=pNahKJLszKr8J00u
      */
     public static function getYouTubeIdFromUrl(string $url): ?string
     {
         if (empty($url)) {
             return null;
         }
-        
+
         $parts = parse_url($url);
+        if (!is_array($parts)) {
+            return null;
+        }
+
         $query = $parts['query'] ?? null;
         $path = $parts['path'] ?? null;
-        
+
         if ($query) {
             parse_str($query, $qs);
 
-            $v = $qs['v'] ?? null;
-            $vi = $qs['vi'] ?? null;
-            
-            if ($v || $vi) {
-                return $v ?? $vi;
+            // When a v/vi key is present it owns the result. parse_str yields an
+            // array for ?v[]= style params; those are not valid IDs (and would
+            // be a TypeError against the ?string return — issue #34), so reject.
+            if (array_key_exists('v', $qs) || array_key_exists('vi', $qs)) {
+                $id = $qs['v'] ?? $qs['vi'] ?? null;
+                return is_string($id) ? self::validateYouTubeId($id) : null;
             }
         }
 
@@ -86,10 +112,10 @@ class ParsingHelper
             // YouTube Shorts URLs are /shorts/{id} — the ID is the second
             // segment. Return null (not "shorts") when the ID is absent.
             if (strtolower($explodedPath[0] ?? '') === self::YOUTUBE_SHORTS_PREFIX) {
-                return $explodedPath[1] ?? null;
+                return self::validateYouTubeId($explodedPath[1] ?? null);
             }
 
-            return $explodedPath[0] ?? null;
+            return self::validateYouTubeId($explodedPath[0] ?? null);
         }
 
         return null;
@@ -115,6 +141,19 @@ class ParsingHelper
         $segments = explode('/', trim($path, '/'));
 
         return strtolower($segments[0] ?? '') === self::YOUTUBE_SHORTS_PREFIX;
+    }
+
+    /**
+     * Validates a YouTube video ID against YouTube's character set
+     * (A–Z, a–z, 0–9, hyphen, underscore). Returns null for anything else so
+     * untrusted input is never interpolated into embed or image URLs.
+     */
+    private static function validateYouTubeId(?string $id): ?string
+    {
+        if ($id === null || $id === '') {
+            return null;
+        }
+        return preg_match('/^[A-Za-z0-9_-]+$/', $id) ? $id : null;
     }
     
     /**

--- a/src/services/VideoEmbed.php
+++ b/src/services/VideoEmbed.php
@@ -3,8 +3,7 @@
 namespace viget\videoembed\services;
 
 use craft\base\Component;
-use Craft;
-use craft\errors\DeprecationException;
+use viget\videoembed\enums\VideoType;
 use viget\videoembed\helpers\ParsingHelper;
 use viget\videoembed\models\VideoData;
 
@@ -20,101 +19,20 @@ class VideoEmbed extends Component
     }
 
     /**
-     * Take a YouTube or Vimeo url and return the embed url
-     *
-     * @param string $url
-     * @return string|null
-     * @throws DeprecationException
-     * @deprecated v2.0.2
-     * @see self::getVideoData()
+     * Takes a YouTube or Vimeo URL and returns the embed URL string, or null if
+     * the URL cannot be parsed. Convenience wrapper over getVideoData() for
+     * callers that only need the iframe src.
      */
     public function getEmbedUrl(string $url): ?string
     {
-        Craft::$app->getDeprecator()->log(__METHOD__, 'use getVideoData() instead');
-
-        if ($this->_isYoutube($url)) {
-            $urlParts = parse_url($url);
-            $query = $urlParts['query'] ?? null;
-
-            if ($query === null) {
-                return null;
-            }
-
-            parse_str($query, $segments);
-            $v = $segments['v'] ?? null;
-
-            if ($v === null) {
-                return null;
-            }
-
-            return '//www.youtube.com/embed/' . $v;
-        }
-
-        if ($this->_isShortYoutube($url)) {
-            $urlParts = parse_url($url);
-            $path = $urlParts['path'] ?? null;
-
-            if ($path === null) return null;
-
-            return '//www.youtube.com/embed' . $path;
-        }
-
-        if ($this->_isVimeo($url)) {
-            $urlParts = parse_url($url);
-            $path = $urlParts['path'] ?? null;
-
-            if ($path === null) {
-                return null;
-            }
-
-            $segments = explode('/', $path);
-            $firstSegment = $segments[1] ?? null;
-
-            if ($firstSegment === null) return null;
-
-            return '//player.vimeo.com/video/' . $firstSegment . '?player_id=video&api=1';
-        }
-
-        return null;
+        return $this->getVideoData($url)?->embedUrl;
     }
 
     /**
      * Determine whether the url is a YouTube or Vimeo url
-     * @param string $url
-     * @return boolean
      */
     public function isVideoUrl(string $url): bool
     {
-        return ($this->_isYoutube($url) || $this->_isShortYoutube($url) || $this->_isVimeo($url));
-    }
-
-    /**
-     * Is the url a YouTube url
-     * @param string $url
-     * @return boolean
-     */
-    private function _isYoutube(string $url): bool
-    {
-        return strripos($url, 'youtube.com') !== FALSE;
-    }
-
-    /**
-     * Is the url a YouTube short url
-     * @param string $url
-     * @return boolean
-     */
-    private function _isShortYoutube(string $url): bool
-    {
-        return strripos($url, 'youtu.be') !== FALSE;
-    }
-
-    /**
-     * Is the url a Vimeo url
-     * @param string $url
-     * @return boolean
-     */
-    private function _isVimeo($url): bool
-    {
-        return strripos($url, 'vimeo.com') !== FALSE;
+        return ParsingHelper::getVideoTypeFromUrl($url) !== VideoType::UNKNOWN;
     }
 }

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -14,6 +14,97 @@ final class ParsingHelperTest extends TestCase
         );
     }
 
+    public function testGetVideoTypeFromUrlReturnsUnknownForMalformedInput(): void
+    {
+        $this->assertEquals(VideoType::UNKNOWN, ParsingHelper::getVideoTypeFromUrl(''));
+        $this->assertEquals(VideoType::UNKNOWN, ParsingHelper::getVideoTypeFromUrl('not a url'));
+    }
+
+    /**
+     * Non-http/https schemes must return UNKNOWN before the host is trusted.
+     */
+    public function testGetVideoTypeFromUrlRejectsNonHttpSchemes(): void
+    {
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('javascript://youtube.com/watch?v=ID')
+        );
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('ftp://youtube.com/watch?v=ID')
+        );
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('//youtube.com/watch?v=ID')
+        );
+    }
+
+    /**
+     * Exact host matching: a domain that merely contains "youtube.com" or
+     * "vimeo.com" as a substring must not be treated as that provider.
+     */
+    public function testGetVideoTypeFromUrlRejectsFakeHosts(): void
+    {
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('https://notyoutube.com/watch?v=ID')
+        );
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('https://attackervimeo.com/12345')
+        );
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('https://evil.com/?r=https://youtube.com/watch?v=ID')
+        );
+    }
+
+    /**
+     * Mobile (m.) and YouTube Music (music.) subdomains must still resolve to
+     * YouTube (issue #36).
+     */
+    public function testGetVideoTypeFromUrlAcceptsYouTubeSubdomains(): void
+    {
+        $this->assertEquals(
+            VideoType::YOUTUBE,
+            ParsingHelper::getVideoTypeFromUrl('https://m.youtube.com/watch?v=ID')
+        );
+        $this->assertEquals(
+            VideoType::YOUTUBE,
+            ParsingHelper::getVideoTypeFromUrl('https://music.youtube.com/watch?v=ID')
+        );
+    }
+
+    /**
+     * IDs containing characters outside [A-Za-z0-9_-] must return null so they
+     * are never interpolated into embed or image URLs.
+     */
+    public function testGetYouTubeIdFromUrlRejectsInjectionPayloads(): void
+    {
+        $this->assertNull(
+            ParsingHelper::getYouTubeIdFromUrl('https://youtu.be/VALID_ID" onload="alert(1)')
+        );
+        $this->assertNull(
+            ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/watch?v=<script>alert(1)</script>')
+        );
+        $this->assertNull(
+            ParsingHelper::getYouTubeIdFromUrl('https://youtu.be/VALID ID')
+        );
+        $this->assertNull(
+            ParsingHelper::getYouTubeIdFromUrl('https://youtu.be/../evil')
+        );
+    }
+
+    /**
+     * Array-valued query params (?v[]=) must not throw a TypeError (issue #34).
+     */
+    public function testGetYouTubeIdFromUrlRejectsArrayQueryParam(): void
+    {
+        $this->assertNull(
+            ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/watch?v[]=abc')
+        );
+    }
+
     public function testGetYouTubeIdFromUrl(): void
     {
         $this->assertEquals(


### PR DESCRIPTION
Centralizes URL trust in `ParsingHelper` and removes the service's `strripos` substring host matching.

## Changes
- `getVideoTypeFromUrl()`: guard `parse_url()` returning `false`; reject non-`http(s)` and protocol-relative URLs; exact host match. A leading `www.`, `m.`, or `music.` prefix is stripped so mobile and YouTube Music links still resolve (refs #36).
- `getYouTubeIdFromUrl()`: `parse_url` guard; validate IDs against `[A-Za-z0-9_-]`; reject array-valued `?v[]=` params that previously threw a `TypeError` (refs #34).
- `VideoEmbed` service: `getEmbedUrl()` is now a thin wrapper over `getVideoData()` (no longer deprecated); `isVideoUrl()` delegates to `getVideoTypeFromUrl()`; `strripos` helpers removed.

## Behavior change to flag
`getEmbedUrl()` previously returned a protocol-relative `//www.youtube.com/embed/{v}` and, for Vimeo, appended legacy Froogaloop params (`?player_id=video&api=1`). It now returns `getVideoData()->embedUrl` — an `https://` URL without those params (relevant to #39).

## Notes
- Touches `getYouTubeIdFromUrl()`, which the Shorts PR also edits — trivial rebase for whichever merges second.

Tests: 12 passing.
