### PR TITLE
Move schemaVersion to plugin class; guard plugin-loaded log (#38)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
     "extra": {
         "name": "Video Embed",
         "handle": "video-embed",
-        "schemaVersion": "3.0.0",
         "hasCpSettings": false,
         "hasCpSection": false,
         "changelogUrl": "https://raw.githubusercontent.com/vigetlabs/craft-videoembed/v3/CHANGELOG.md",

--- a/src/VideoEmbed.php
+++ b/src/VideoEmbed.php
@@ -46,9 +46,7 @@ class VideoEmbed extends Plugin
     // =========================================================================
 
     /**
-     * The plugin's schema version, used by Craft to track install/migration
-     * state. Declared on the plugin class per Craft 5 conventions rather than
-     * in composer.json's `extra` block.
+     * @inheritDoc
      */
     public string $schemaVersion = '3.0.0';
 

--- a/src/VideoEmbed.php
+++ b/src/VideoEmbed.php
@@ -31,9 +31,26 @@ class VideoEmbed extends Plugin
     // =========================================================================
 
     /**
+     * Static reference to this plugin instance.
+     *
      * @var VideoEmbed
+     * @todo v4 — remove this property. Consumers should resolve the service via
+     *       Craft::$app->getPlugins()->getPlugin('video-embed') or the
+     *       `craft.videoEmbed` Twig variable. Static plugin references are an
+     *       anti-pattern in Craft 5+; this exists only for backwards
+     *       compatibility.
      */
     public static VideoEmbed $plugin;
+
+    // Public Properties
+    // =========================================================================
+
+    /**
+     * The plugin's schema version, used by Craft to track install/migration
+     * state. Declared on the plugin class per Craft 5 conventions rather than
+     * in composer.json's `extra` block.
+     */
+    public string $schemaVersion = '3.0.0';
 
     // Public Methods
     // =========================================================================
@@ -56,13 +73,15 @@ class VideoEmbed extends Plugin
             }
         );
 
-        Craft::info(
-            Craft::t(
-                'video-embed',
-                '{name} plugin loaded',
-                ['name' => $this->name]
-            ),
-            __METHOD__
-        );
+        if (Craft::$app->getConfig()->getGeneral()->devMode) {
+            Craft::info(
+                Craft::t(
+                    'video-embed',
+                    '{name} plugin loaded',
+                    ['name' => $this->name]
+                ),
+                __METHOD__
+            );
+        }
     }
 }

--- a/src/translations/en/video-embed.php
+++ b/src/translations/en/video-embed.php
@@ -14,5 +14,5 @@
  * @since     1.2.0
  */
 return [
-    'Video Embed plugin loaded' => 'Video Embed plugin loaded',
+    '{name} plugin loaded' => '{name} plugin loaded',
 ];


### PR DESCRIPTION
Addresses #38.

## Changes
- Declares `schemaVersion` on the plugin class (`public string $schemaVersion`) per Craft 5 convention, and removes the legacy `extra.schemaVersion` from `composer.json`. (Verified `craft\base\PluginTrait` declares `public string $schemaVersion`.)
- Wraps the "plugin loaded" `Craft::info()` call in a `devMode` guard so it stops logging on every production request.
- Adds a `@todo v4` note to the static `$plugin` reference (anti-pattern in Craft 5+).
- Translation key updated to match the `{name} plugin loaded` message.
