### PR TITLE
Add rel=0 to YouTube embeds + embedUrlWithParams() helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,15 @@ If the plugin is unable to parse the URL, `null` is returned.
 
 **Output:**
 
+```html
+<iframe src="https://www.youtube.com/embed/6xWpo5Dn254?rel=0"></iframe>
 ```
-<iframe src="//www.youtube.com/embed/6xWpo5Dn254"></iframe>
+
+YouTube embed URLs include `rel=0` so related-video suggestions stay on the same channel. Because `embedUrl` already carries a query string, add your own player params with `embedUrlWithParams` rather than concatenating onto `embedUrl`:
+
+```twig
+<iframe src="{{ video.embedUrlWithParams({ autoplay: 1, mute: 1 }) }}"></iframe>
+{# → https://www.youtube.com/embed/6xWpo5Dn254?rel=0&autoplay=1&mute=1 #}
 ```
 
 ***

--- a/src/models/VideoData.php
+++ b/src/models/VideoData.php
@@ -27,10 +27,29 @@ class VideoData
             type: VideoType::YOUTUBE->value,
             id: $youtubeId,
             image: "https://i.ytimg.com/vi/{$youtubeId}/hqdefault.jpg",
-            embedUrl: "https://www.youtube.com/embed/{$youtubeId}",
+            embedUrl: "https://www.youtube.com/embed/{$youtubeId}?rel=0",
             url: "https://www.youtube.com/watch?v={$youtubeId}",
             isVertical: $isVertical,
         );
+    }
+
+    /**
+     * Returns the embed URL with additional query params merged in — e.g.
+     * `video.embedUrlWithParams({ autoplay: 1, mute: 1 })`. Use this instead of
+     * concatenating onto `embedUrl`, which already carries a query string
+     * (YouTube `rel=0`, or a Vimeo privacy `h` hash). Caller params override
+     * existing ones of the same name; everything is joined with `&` correctly.
+     */
+    public function embedUrlWithParams(array $params = []): string
+    {
+        if (!$params) {
+            return $this->embedUrl;
+        }
+
+        [$base, $existingQuery] = array_pad(explode('?', $this->embedUrl, 2), 2, '');
+        parse_str($existingQuery, $existing);
+
+        return $base . '?' . http_build_query(array_merge($existing, $params));
     }
 
     public static function forVimeo(?string $vimeoId, ?string $vimeoHash = null): ?static

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -173,7 +173,7 @@ final class ParsingHelperTest extends TestCase
         $this->assertNotNull($video);
         $this->assertTrue($video->isVertical);
         $this->assertEquals('dQw4w9WgXcQ', $video->id);
-        $this->assertEquals('https://www.youtube.com/embed/dQw4w9WgXcQ', $video->embedUrl);
+        $this->assertEquals('https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0', $video->embedUrl);
     }
 
     public function testIsVerticalIsFalseForNonShortsYouTube(): void
@@ -200,6 +200,53 @@ final class ParsingHelperTest extends TestCase
     {
         $this->assertNull(
             ParsingHelper::getVideoDataFromUrl('https://example.com/video')
+        );
+    }
+
+    /**
+     * YouTube embed URLs include rel=0 so related-video suggestions stay on the
+     * same channel (YouTube removed full suppression in September 2018).
+     */
+    public function testGetYouTubeEmbedUrlIncludesRel0(): void
+    {
+        $this->assertEquals(
+            'https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0',
+            ParsingHelper::getVideoDataFromUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')->embedUrl
+        );
+    }
+
+    /**
+     * embedUrlWithParams merges caller params into the existing query string
+     * (rel=0 for YouTube, the h= hash for Vimeo) without manual concatenation.
+     */
+    public function testEmbedUrlWithParams(): void
+    {
+        $video = ParsingHelper::getVideoDataFromUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+
+        $this->assertEquals(
+            'https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0',
+            $video->embedUrlWithParams(),
+            'no params returns embedUrl unchanged'
+        );
+
+        $this->assertEquals(
+            'https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0&autoplay=1',
+            $video->embedUrlWithParams(['autoplay' => 1]),
+            'extra params join with &'
+        );
+
+        $this->assertEquals(
+            'https://www.youtube.com/embed/dQw4w9WgXcQ?rel=1',
+            $video->embedUrlWithParams(['rel' => 1]),
+            'caller params override existing ones'
+        );
+
+        // Vimeo: merges with the existing privacy-hash param.
+        $vimeo = ParsingHelper::getVideoDataFromUrl('https://vimeo.com/9999999999/0000000000');
+
+        $this->assertEquals(
+            'https://player.vimeo.com/video/9999999999?h=0000000000&autoplay=1',
+            $vimeo->embedUrlWithParams(['autoplay' => 1])
         );
     }
 }


### PR DESCRIPTION
Adds `rel=0` to YouTube embed URLs so related-video suggestions stay on the same channel. (Since September 2018 YouTube no longer fully suppresses related videos; `rel=0` restricts them to the source channel rather than removing them.)

## Changes
- `VideoData::forYoutube` `embedUrl` now ends with `?rel=0`.
- New `VideoData::embedUrlWithParams(array $params = [])` — merges caller params into the existing query string (caller values override, joined with `&`), so consumers add `autoplay`/`mute`/etc. without hand-concatenating onto a URL that already has `?rel=0`. It also covers the existing Vimeo `?h=` privacy-hash case.
- README documents `rel=0` and the `embedUrlWithParams` usage.

## Notes
- This is a deliberate behavior change to **every** YouTube embed, split out from the Shorts/`isVertical` PR (#40) so it can be reviewed on its own.
- Touches `VideoData::forYoutube` and the test file, which #40 also touches — whichever merges second takes a trivial rebase.

Tests: 8 passing (PHPUnit 11) — `rel=0` output, param merge/override, Vimeo hash merge.
