### PR TITLE
Add rel=0 to YouTube embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ If the plugin is unable to parse the URL, `null` is returned.
 
 **Output:**
 
+```html
+<iframe src="https://www.youtube.com/embed/6xWpo5Dn254?rel=0"></iframe>
 ```
-<iframe src="//www.youtube.com/embed/6xWpo5Dn254"></iframe>
-```
+
+YouTube embed URLs include `rel=0` so related-video suggestions stay on the same channel rather than promoting unrelated videos.
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ If the plugin is unable to parse the URL, `null` is returned.
 
 YouTube embed URLs include `rel=0` so related-video suggestions stay on the same channel rather than promoting unrelated videos.
 
+### Customizing URL params
+
+Because `embedUrl` already carries a query string (YouTube's `rel=0`, or a Vimeo privacy `h` hash), add your own player params with Craft's built-in [`url()`](https://craftcms.com/docs/5.x/reference/twig/functions.html#url) function rather than concatenating onto `embedUrl`. `url()` preserves the existing params and merges in your own:
+
+```twig
+<iframe src="{{ url(video.embedUrl, { autoplay: 1, mute: 1 }) }}"></iframe>
+{# → https://www.youtube.com/embed/6xWpo5Dn254?rel=0&autoplay=1&mute=1 #}
+```
+
 ***
 
 <a href="http://code.viget.com">

--- a/src/models/VideoData.php
+++ b/src/models/VideoData.php
@@ -27,7 +27,7 @@ class VideoData
             type: VideoType::YOUTUBE->value,
             id: $youtubeId,
             image: "https://i.ytimg.com/vi/{$youtubeId}/hqdefault.jpg",
-            embedUrl: "https://www.youtube.com/embed/{$youtubeId}",
+            embedUrl: "https://www.youtube.com/embed/{$youtubeId}?rel=0",
             url: "https://www.youtube.com/watch?v={$youtubeId}",
             isVertical: $isVertical,
         );

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -257,7 +257,7 @@ final class ParsingHelperTest extends TestCase
         $this->assertNotNull($video);
         $this->assertTrue($video->isVertical);
         $this->assertEquals('dQw4w9WgXcQ', $video->id);
-        $this->assertEquals('https://www.youtube.com/embed/dQw4w9WgXcQ', $video->embedUrl);
+        $this->assertEquals('https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0', $video->embedUrl);
     }
 
     public function testIsVerticalIsFalseForNonShortsYouTube(): void
@@ -284,6 +284,18 @@ final class ParsingHelperTest extends TestCase
     {
         $this->assertNull(
             ParsingHelper::getVideoDataFromUrl('https://example.com/video')
+        );
+    }
+
+    /**
+     * YouTube embed URLs include rel=0 so related-video suggestions stay on the
+     * same channel (YouTube removed full suppression in September 2018).
+     */
+    public function testGetYouTubeEmbedUrlIncludesRel0(): void
+    {
+        $this->assertEquals(
+            'https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0',
+            ParsingHelper::getVideoDataFromUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')->embedUrl
         );
     }
 }


### PR DESCRIPTION
Adds `rel=0` to YouTube embed URLs so related-video suggestions stay on the source channel rather than promoting unrelated videos. (Since September 2018 YouTube no longer fully suppresses related videos; `rel=0` restricts them to the source channel rather than removing them.)

This is the `rel=0` portion of #44, split out on its own. The `embedUrlWithParams()` helper from that PR is intentionally not included here.

## Changes
- `VideoData::forYoutube` `embedUrl` now ends with `?rel=0`.
- README documents the `rel=0` behavior.

## Notes
- This is a deliberate behavior change to **every** YouTube embed.

Tests: 19 passing (PHPUnit 11).