### PR TITLE
Parser hardening: Vimeo hash validation, reserved YouTube segments, stacked host prefixes (#49, #50, #52)

### DIFF
--- a/src/helpers/ParsingHelper.php
+++ b/src/helpers/ParsingHelper.php
@@ -108,11 +108,18 @@ class ParsingHelper
          */
         if ($path) {
             $explodedPath = explode('/', trim($path, '/'));
+            $first = strtolower($explodedPath[0] ?? '');
 
-            // YouTube Shorts URLs are /shorts/{id} — the ID is the second
-            // segment. Return null (not "shorts") when the ID is absent.
-            if (strtolower($explodedPath[0] ?? '') === self::YOUTUBE_SHORTS_PREFIX) {
+            // /shorts/{id}, /embed/{id}, /live/{id} carry the ID in the SECOND
+            // segment. Return null (not the route name) when the ID is absent.
+            if (in_array($first, [self::YOUTUBE_SHORTS_PREFIX, 'embed', 'live'], true)) {
                 return self::validateYouTubeId($explodedPath[1] ?? null);
+            }
+
+            // Known non-ID routes never carry a bare video ID as the first
+            // segment (issue #50) — don't treat "watch", "playlist", etc. as IDs.
+            if (in_array($first, ['watch', 'playlist', 'feed', 'channel', 'results', 'c', 'user'], true)) {
+                return null;
             }
 
             return self::validateYouTubeId($explodedPath[0] ?? null);

--- a/src/helpers/ParsingHelper.php
+++ b/src/helpers/ParsingHelper.php
@@ -49,11 +49,11 @@ class ParsingHelper
             return VideoType::UNKNOWN;
         }
 
-        // Strip a leading www. or a known YouTube subdomain (m., music.) so
-        // mobile and YouTube Music links still resolve (issue #36). Only a
-        // leading prefix is removed — a substring match would let e.g.
-        // "notyoutube.com" through.
-        $host = preg_replace('/^(www|m|music)\./', '', strtolower($host));
+        // Strip leading www. / m. / music. prefixes, including stacked ones like
+        // www.m.youtube.com (issue #52), so mobile and YouTube Music links still
+        // resolve (issue #36). Only anchored leading prefixes are removed — a
+        // substring match would let e.g. "notyoutube.com" through.
+        $host = preg_replace('/^(?:www\.|m\.|music\.)+/', '', strtolower($host));
 
         if (in_array($host, self::YOUTUBE_URLS, true)) {
             return VideoType::YOUTUBE;

--- a/src/helpers/ParsingHelper.php
+++ b/src/helpers/ParsingHelper.php
@@ -231,11 +231,15 @@ class ParsingHelper
     {
         $parts = parse_url($url);
 
-        // player.vimeo.com uses ?h= query param
+        // player.vimeo.com uses ?h= query param. parse_str() yields an array for
+        // ?h[]= style params; reject non-strings before the ?string return
+        // (issue #49) and validate the charset so untrusted input never reaches
+        // the embed URL.
         if (isset($parts['query'])) {
             parse_str($parts['query'], $qs);
-            if (!empty($qs['h'])) {
-                return $qs['h'];
+            $h = $qs['h'] ?? null;
+            if (is_string($h) && $h !== '') {
+                return self::validateVimeoHash($h);
             }
         }
 
@@ -254,7 +258,20 @@ class ParsingHelper
             return null;
         }
 
-        return $segments[1] ?? null;
+        return self::validateVimeoHash($segments[1] ?? null);
+    }
+
+    /**
+     * Validates a Vimeo private hash against Vimeo's character set (A–Z, a–z,
+     * 0–9). Returns null for anything else so untrusted input is never
+     * interpolated into the embed or canonical URL — mirrors validateYouTubeId().
+     */
+    private static function validateVimeoHash(?string $hash): ?string
+    {
+        if ($hash === null || $hash === '') {
+            return null;
+        }
+        return preg_match('/^[A-Za-z0-9]+$/', $hash) ? $hash : null;
     }
 
 }

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -447,30 +447,29 @@ final class ParsingHelperTest extends TestCase
     }
 
     /**
-     * Characterizes current behavior — flipped by #50.
-     *
-     * With no ?v= present, the first path segment is trusted as the video ID, so
-     * reserved routes are returned verbatim as bogus IDs. #50 will treat
-     * embed/live like shorts (ID is the second segment) and return null for
-     * non-ID routes such as watch/playlist.
+     * Reserved routes are no longer mistaken for video IDs (issue #50):
+     * embed/live carry the ID in the second segment (like shorts), while
+     * watch/playlist have no bare ID and return null instead of the route name.
      */
-    public function testCharacterizeReservedPathSegmentsReturnedAsIds(): void
+    public function testGetYouTubeIdHandlesReservedPathSegments(): void
     {
         $this->assertEquals(
-            'embed',
+            'dQw4w9WgXcQ',
             ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/embed/dQw4w9WgXcQ')
         );
         $this->assertEquals(
-            'live',
+            'dQw4w9WgXcQ',
             ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/live/dQw4w9WgXcQ')
         );
-        $this->assertEquals(
-            'watch',
+        $this->assertNull(
             ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/watch')
         );
-        $this->assertEquals(
-            'playlist',
+        $this->assertNull(
             ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/playlist?list=PL1')
+        );
+        // /embed with no ID returns null, not the literal "embed".
+        $this->assertNull(
+            ParsingHelper::getYouTubeIdFromUrl('https://www.youtube.com/embed')
         );
     }
 

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -416,30 +416,33 @@ final class ParsingHelperTest extends TestCase
     }
 
     /**
-     * Characterizes current behavior — flipped by #49.
-     *
-     * An array-valued ?h[]= param makes parse_str() yield an array, which
-     * violates the ?string return type and throws a TypeError. #49 will guard the
-     * value and return null instead.
+     * An array-valued ?h[]= param must not throw a TypeError; it is rejected and
+     * returns null (issue #49, mirroring the YouTube ?v[]= fix from #34).
      */
-    public function testCharacterizeVimeoHashArrayParamThrows(): void
+    public function testGetVimeoHashRejectsArrayQueryParam(): void
     {
-        $this->expectException(\TypeError::class);
-        ParsingHelper::getVimeoHashFromUrl('https://player.vimeo.com/video/123?h[]=abc');
+        $this->assertNull(
+            ParsingHelper::getVimeoHashFromUrl('https://player.vimeo.com/video/123?h[]=abc')
+        );
     }
 
     /**
-     * Characterizes current behavior — flipped by #49.
-     *
-     * The path-form hash is returned without charset validation, so injection
-     * characters flow through untouched into the embed URL. #49 will validate the
-     * hash charset and return null for this input.
+     * Hash values outside [A-Za-z0-9] are rejected so untrusted characters never
+     * reach the embed/canonical URL (issue #49); valid hashes still resolve, in
+     * both the path (vimeo.com/{id}/{hash}) and query (?h=) forms.
      */
-    public function testCharacterizeVimeoHashSkipsCharsetValidation(): void
+    public function testGetVimeoHashValidatesCharset(): void
     {
-        $this->assertEquals(
-            'abc"onload',
+        $this->assertNull(
             ParsingHelper::getVimeoHashFromUrl('https://vimeo.com/12345/abc"onload')
+        );
+        $this->assertEquals(
+            'a1b2c3d4e5',
+            ParsingHelper::getVimeoHashFromUrl('https://vimeo.com/12345/a1b2c3d4e5')
+        );
+        $this->assertEquals(
+            'a1b2c3d4e5',
+            ParsingHelper::getVimeoHashFromUrl('https://player.vimeo.com/video/12345?h=a1b2c3d4e5')
         );
     }
 

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -474,17 +474,23 @@ final class ParsingHelperTest extends TestCase
     }
 
     /**
-     * Characterizes current behavior — flipped by #52.
-     *
-     * The host prefix strip removes only one leading label, so a stacked prefix
-     * (www.m.youtube.com) falls through to UNKNOWN. #52 will strip stacked
-     * prefixes while keeping the anchored (non-substring) match.
+     * Stacked leading prefixes (www.m.youtube.com) resolve to YouTube (issue
+     * #52), while the anchored match still rejects look-alike hosts that merely
+     * contain the domain as a substring.
      */
-    public function testCharacterizeStackedHostPrefixRejected(): void
+    public function testGetVideoTypeAcceptsStackedHostPrefixes(): void
     {
         $this->assertEquals(
-            VideoType::UNKNOWN,
+            VideoType::YOUTUBE,
             ParsingHelper::getVideoTypeFromUrl('https://www.m.youtube.com/watch?v=abc')
+        );
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('https://music.youtube.com.evil.com/watch?v=abc')
+        );
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('https://notyoutube.com/watch?v=abc')
         );
     }
 


### PR DESCRIPTION
First Phase 2 grouping of the PR #42 follow-ups: the three independent `ParsingHelper` hardening fixes, landed against the merged characterization baseline (#56). Each is an atomic commit that flips its baseline characterization test to assert the corrected behavior.

Addresses #49, #50, #52. Sequenced per `docs/plans/2026-07-08-001-fix-pr42-followups-plan.md`.

## Fixes

| Commit | Issue | Change |
|--------|-------|--------|
| `ad0a927` | **#49** | `getVimeoHashFromUrl()` guards array-valued `?h[]=` params (`is_string` check) that previously threw a `TypeError` against the `?string` return, and routes both the `?h=` query and `vimeo.com/{id}/{hash}` path forms through a new `validateVimeoHash()` (`[A-Za-z0-9]`) so untrusted input never reaches the embed/canonical URL — mirroring `validateYouTubeId()`. |
| `10af1d7` | **#50** | `getYouTubeIdFromUrl()` no longer trusts the first path segment as the ID: `embed`/`live` are treated like `shorts` (ID is the second segment), and known non-ID routes (`watch`, `playlist`, `feed`, `channel`, `results`, `c`, `user`) return `null` instead of the route name. |
| `63559c4` | **#52** | Host prefix strip uses a repeated anchored group (`/^(?:www\.\|m\.\|music\.)+/`) so stacked prefixes like `www.m.youtube.com` resolve, while look-alike hosts (`music.youtube.com.evil.com`, `notyoutube.com`) still return `UNKNOWN`. |

## Characterization → regression

The baseline committed tests that pinned each defect (tagged "flipped by #NN"). This PR flips them to assert the fixed behavior, so the diff shows exactly what moved:

- `testCharacterizeVimeoHashArrayParamThrows` / `…SkipsCharsetValidation` → `testGetVimeoHashRejectsArrayQueryParam` / `testGetVimeoHashValidatesCharset`
- `testCharacterizeReservedPathSegmentsReturnedAsIds` → `testGetYouTubeIdHandlesReservedPathSegments`
- `testCharacterizeStackedHostPrefixRejected` → `testGetVideoTypeAcceptsStackedHostPrefixes`

## Verification

- `composer phpunit` → **38 tests, 85 assertions, green.**
- Each fix was exercised directly (array param no longer throws; `embed`/`live` yield the real ID; `www.m.youtube.com` resolves), along with regressions (`watch?v=`, `youtu.be`, `shorts`, `www./m./music.` subdomains, Vimeo) and fail-safes (look-alike hosts stay `UNKNOWN`).
- `+80 / -48`, only `src/helpers/ParsingHelper.php` and `tests/ParsingHelperTest.php`.

## Scope

Deliberately excludes the contract-changing pair (#51 scheme-less normalization, #54 `isVideoUrl`/`getVideoData` alignment) and the 3.1.0 docs (#55) — those follow in separate PRs so the behavior-changing work is reviewed on its own.

## CI note

`v3`s `tests` workflow may currently be red from the upstream Composer 2.9+ advisory-resolution issue (a fresh `composer update` blocked by Craft-transitive twig/webauthn advisories), which is unrelated to this diff — these tests pass locally.