### PR TITLE
URL contract fixes: normalize scheme-less input, align isVideoUrl with getVideoData (#51, #54)

### DIFF
--- a/src/helpers/ParsingHelper.php
+++ b/src/helpers/ParsingHelper.php
@@ -30,7 +30,7 @@ class ParsingHelper
     
     public static function getVideoTypeFromUrl(string $url): VideoType
     {
-        $parsedUrl = parse_url($url);
+        $parsedUrl = parse_url(self::normalizeUrl($url));
 
         // parse_url() returns false on seriously malformed input.
         if (!is_array($parsedUrl)) {
@@ -80,7 +80,7 @@ class ParsingHelper
             return null;
         }
 
-        $parts = parse_url($url);
+        $parts = parse_url(self::normalizeUrl($url));
         if (!is_array($parts)) {
             return null;
         }
@@ -139,7 +139,7 @@ class ParsingHelper
      */
     private static function isYouTubeShortsUrl(string $url): bool
     {
-        $path = parse_url($url, PHP_URL_PATH);
+        $path = parse_url(self::normalizeUrl($url), PHP_URL_PATH);
 
         if (!$path) {
             return false;
@@ -148,6 +148,28 @@ class ParsingHelper
         $segments = explode('/', trim($path, '/'));
 
         return strtolower($segments[0] ?? '') === self::YOUTUBE_SHORTS_PREFIX;
+    }
+
+    /**
+     * Prepends https:// to scheme-less, host-like input (e.g.
+     * "www.youtube.com/watch?v=x") so editor pastes without a scheme resolve
+     * consistently across every parse method (issue #51). Protocol-relative
+     * URLs (//host) and anything carrying an explicit scheme (javascript:, ftp:)
+     * are left untouched, so getVideoTypeFromUrl()'s http(s)-only guard still
+     * rejects them.
+     */
+    private static function normalizeUrl(string $url): string
+    {
+        $parsed = parse_url($url);
+        if (
+            is_array($parsed)
+            && !isset($parsed['scheme'])
+            && !isset($parsed['host'])
+            && !str_starts_with($url, '//')
+        ) {
+            return 'https://' . $url;
+        }
+        return $url;
     }
 
     /**
@@ -180,7 +202,7 @@ class ParsingHelper
      */
     public static function getVimeoIdFromUrl(string $url): ?string
     {
-        $parts = parse_url($url);
+        $parts = parse_url(self::normalizeUrl($url));
         $path = $parts['path'] ?? null;
 
         if (!$path) {
@@ -236,7 +258,7 @@ class ParsingHelper
      */
     public static function getVimeoHashFromUrl(string $url): ?string
     {
-        $parts = parse_url($url);
+        $parts = parse_url(self::normalizeUrl($url));
 
         // player.vimeo.com uses ?h= query param. parse_str() yields an array for
         // ?h[]= style params; reject non-strings before the ?string return

--- a/src/services/VideoEmbed.php
+++ b/src/services/VideoEmbed.php
@@ -3,7 +3,6 @@
 namespace viget\videoembed\services;
 
 use craft\base\Component;
-use viget\videoembed\enums\VideoType;
 use viget\videoembed\helpers\ParsingHelper;
 use viget\videoembed\models\VideoData;
 
@@ -29,10 +28,14 @@ class VideoEmbed extends Component
     }
 
     /**
-     * Determine whether the url is a YouTube or Vimeo url
+     * Determines whether the URL is an embeddable YouTube or Vimeo video.
+     *
+     * Returns true only when getVideoData() can produce usable data, so a true
+     * result guarantees a non-null getVideoData()/getEmbedUrl() — a host-valid
+     * URL with no extractable ID (e.g. https://youtube.com/) is not a video URL.
      */
     public function isVideoUrl(string $url): bool
     {
-        return ParsingHelper::getVideoTypeFromUrl($url) !== VideoType::UNKNOWN;
+        return ParsingHelper::getVideoDataFromUrl($url) !== null;
     }
 }

--- a/tests/ParsingHelperTest.php
+++ b/tests/ParsingHelperTest.php
@@ -495,17 +495,53 @@ final class ParsingHelperTest extends TestCase
     }
 
     /**
-     * Characterizes current behavior — flipped by #51.
-     *
-     * A scheme-less URL yields no host under parse_url(), so it is rejected. #51
-     * will normalize scheme-less, host-like input by prepending https:// before
-     * parsing (javascript:/ftp: still carry a scheme and stay rejected).
+     * Scheme-less, host-like pastes are normalized (https:// assumed) and
+     * resolve end-to-end (issue #51), while protocol-relative and non-http
+     * schemes stay rejected.
      */
-    public function testCharacterizeSchemelessUrlRejected(): void
+    public function testGetVideoTypeNormalizesSchemelessUrls(): void
     {
         $this->assertEquals(
-            VideoType::UNKNOWN,
+            VideoType::YOUTUBE,
             ParsingHelper::getVideoTypeFromUrl('www.youtube.com/watch?v=abc')
         );
+        $this->assertEquals(
+            VideoType::YOUTUBE,
+            ParsingHelper::getVideoTypeFromUrl('youtu.be/dQw4w9WgXcQ')
+        );
+        $this->assertEquals(
+            VideoType::VIMEO,
+            ParsingHelper::getVideoTypeFromUrl('vimeo.com/12345')
+        );
+
+        // Protocol-relative and non-http schemes are still rejected.
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('//youtube.com/watch?v=abc')
+        );
+        $this->assertEquals(
+            VideoType::UNKNOWN,
+            ParsingHelper::getVideoTypeFromUrl('javascript://youtube.com/watch?v=abc')
+        );
+    }
+
+    /**
+     * Scheme-less input resolves to usable data end-to-end, not just a type —
+     * getVideoData() extracts the ID and builds the embed URL (issue #51).
+     */
+    public function testGetVideoDataResolvesSchemelessUrls(): void
+    {
+        $youtube = ParsingHelper::getVideoDataFromUrl('www.youtube.com/watch?v=dQw4w9WgXcQ');
+        $this->assertNotNull($youtube);
+        $this->assertEquals('dQw4w9WgXcQ', $youtube->id);
+        $this->assertEquals('https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0', $youtube->embedUrl);
+
+        $short = ParsingHelper::getVideoDataFromUrl('youtu.be/dQw4w9WgXcQ');
+        $this->assertNotNull($short);
+        $this->assertEquals('dQw4w9WgXcQ', $short->id);
+
+        $vimeo = ParsingHelper::getVideoDataFromUrl('vimeo.com/9999999999');
+        $this->assertNotNull($vimeo);
+        $this->assertEquals('9999999999', $vimeo->id);
     }
 }

--- a/tests/VideoEmbedTest.php
+++ b/tests/VideoEmbedTest.php
@@ -78,22 +78,20 @@ final class VideoEmbedTest extends TestCase
     }
 
     /**
-     * Characterizes current behavior — flipped by #54.
-     *
-     * isVideoUrl() validates only the host, while getVideoData() also requires an
-     * extractable ID, so the two disagree for a provider URL that carries no video
-     * ID. This pins the mismatch (a null-deref risk for guard-then-use callers)
-     * that #54 will resolve.
+     * isVideoUrl() now agrees with getVideoData(): it returns true only when an
+     * embeddable video can be produced, so a host-valid URL with no extractable
+     * ID is not a video URL (issue #54) — closing the null-deref surface for
+     * guard-then-use callers.
      */
-    public function testCharacterizeIsVideoUrlAndGetVideoDataDisagree(): void
+    public function testIsVideoUrlAgreesWithGetVideoData(): void
     {
-        $this->assertTrue(
-            $this->service->isVideoUrl('https://youtube.com/'),
-            'Characterizes #54: host-only isVideoUrl() currently returns true'
-        );
-        $this->assertNull(
-            $this->service->getVideoData('https://youtube.com/'),
-            'Characterizes #54: getVideoData() returns null (no extractable ID)'
-        );
+        // Host-valid but no extractable ID: both agree it is not a video.
+        $this->assertFalse($this->service->isVideoUrl('https://youtube.com/'));
+        $this->assertNull($this->service->getVideoData('https://youtube.com/'));
+
+        // Full URLs still resolve to true, matching a non-null getVideoData().
+        $this->assertTrue($this->service->isVideoUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ'));
+        $this->assertNotNull($this->service->getVideoData('https://www.youtube.com/watch?v=dQw4w9WgXcQ'));
+        $this->assertTrue($this->service->isVideoUrl('https://vimeo.com/9999999999'));
     }
 }


### PR DESCRIPTION
Second Phase 2 grouping of the PR #42 follow-ups: the two contract-changing fixes, landed against the merged characterization baseline (#56) and the parser-hardening grouping (#58). Each is an atomic commit that flips its baseline characterization test.

Addresses #51, #54. Sequenced per `docs/plans/2026-07-08-001-fix-pr42-followups-plan.md`.

## Fixes

| Commit | Issue | Change |
|--------|-------|--------|
| `73c0713` | **#51** | New `normalizeUrl()` prepends `https://` to scheme-less, host-like input (e.g. `www.youtube.com/watch?v=x`, `youtu.be/{id}`, `vimeo.com/{id}`) at the entry of every parse method, so `isVideoUrl()` and `getVideoData()` accept editor pastes without a scheme — end-to-end (type + ID + embed URL). Protocol-relative (`//host`) and explicit non-http schemes (`javascript:`, `ftp:`) carry/imply a scheme and stay rejected by the http(s)-only guard. |
| `da99bab` | **#54** | `isVideoUrl()` now delegates to `getVideoDataFromUrl() !== null` instead of a host-only check, so a `true` result guarantees a non-null `getVideoData()`/`getEmbedUrl()`. Closes the null-deref surface where `isVideoUrl('https://youtube.com/')` was `true` but `getVideoData()` was `null` (a fatal deref under Twig `strict_variables`). |

## ⚠️ Behavior changes (for the 3.1.0 changelog — #55)

Both are intentional contract changes to the template-facing `craft.videoEmbed` API:

- **Widened:** scheme-less, host-like URLs are now recognized by `isVideoUrl()`, `getEmbedUrl()`, and `getVideoData()` (previously rejected).
- **Narrowed:** `isVideoUrl()` returns `false` for a host-valid URL with no extractable ID (e.g. `https://youtube.com/`), where it previously returned `true`.

## Characterization → regression

- `testCharacterizeSchemelessUrlRejected` → `testGetVideoTypeNormalizesSchemelessUrls` + a new end-to-end `testGetVideoDataResolvesSchemelessUrls`
- `testCharacterizeIsVideoUrlAndGetVideoDataDisagree` → `testIsVideoUrlAgreesWithGetVideoData`

## Verification

- `composer phpunit` → **39 tests, 99 assertions, green.**
- Exercised directly: scheme-less YouTube/`youtu.be`/Vimeo resolve to usable data; `//host`, `javascript:`, `ftp:`, look-alike hosts, empty/junk stay `UNKNOWN`; `isVideoUrl()` agrees with `getVideoData()` across full URLs, ID-less hosts, reserved segments, and scheme-less input.
- `+89 / -30` across `ParsingHelper.php`, `VideoEmbed.php`, and the two test files.

## Scope / remaining

Only the 3.1.0 release docs (#55) remain — they will document the two behavior changes above plus the earlier `getEmbedUrl` output/Froogaloop changes. That is the last grouping.

## CI note

`v3`s `tests` workflow may still be red from the upstream Composer 2.9+ advisory-resolution issue (unrelated to this diff); these tests pass locally.