### PR TITLE
Document post-3.1.0 URL-parsing changes in the CHANGELOG (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## 3.2.0 - 2026-07-09
 ### Added
 - Scheme-less, host-like URLs (e.g. `www.youtube.com/watch?v=…`, `youtu.be/…`, `vimeo.com/…`) are now recognized by `isVideoUrl()`, `getEmbedUrl()`, and `getVideoData()` [#51](https://github.com/vigetlabs/craft-videoembed/issues/51) [#59](https://github.com/vigetlabs/craft-videoembed/pull/59)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+- Scheme-less, host-like URLs (e.g. `www.youtube.com/watch?v=…`, `youtu.be/…`, `vimeo.com/…`) are now recognized by `isVideoUrl()`, `getEmbedUrl()`, and `getVideoData()` [#51](https://github.com/vigetlabs/craft-videoembed/issues/51) [#59](https://github.com/vigetlabs/craft-videoembed/pull/59)
+
+### Changed
+- `getEmbedUrl()` now returns an absolute `https://` URL instead of a protocol-relative `//…` URL [#42](https://github.com/vigetlabs/craft-videoembed/pull/42)
+- `getEmbedUrl()` is no longer deprecated — it is a supported thin wrapper over `getVideoData()->embedUrl` [#42](https://github.com/vigetlabs/craft-videoembed/pull/42)
+- `isVideoUrl()` now returns `true` only when an embeddable video can be produced, so it agrees with `getVideoData()`; a host-valid URL with no extractable ID (e.g. `https://youtube.com/`) now returns `false` [#54](https://github.com/vigetlabs/craft-videoembed/issues/54) [#59](https://github.com/vigetlabs/craft-videoembed/pull/59)
+- URL matching is now strict: hosts must match exactly (a look-alike such as `notyoutube.com` is rejected) and only `http`/`https` URLs are accepted (protocol-relative and `javascript:`/`ftp:` URLs are rejected) [#42](https://github.com/vigetlabs/craft-videoembed/pull/42)
+
+### Removed
+- `getEmbedUrl()` no longer appends the legacy Vimeo Froogaloop query params (`?player_id=video&api=1`) to Vimeo embed URLs. **Upgrade note:** integrations that drove the Vimeo player through those params should migrate to the [Vimeo Player SDK](https://developer.vimeo.com/player/sdk) [#39](https://github.com/vigetlabs/craft-videoembed/issues/39) [#42](https://github.com/vigetlabs/craft-videoembed/pull/42)
+
+### Fixed
+- YouTube `/embed/{id}` and `/live/{id}` URLs now resolve the correct video ID, and non-video routes (`/watch`, `/playlist`, …) no longer return a bogus ID [#50](https://github.com/vigetlabs/craft-videoembed/issues/50) [#58](https://github.com/vigetlabs/craft-videoembed/pull/58)
+- Stacked host prefixes such as `www.m.youtube.com` are now recognized as YouTube [#52](https://github.com/vigetlabs/craft-videoembed/issues/52) [#58](https://github.com/vigetlabs/craft-videoembed/pull/58)
+- Mobile (`m.`) and YouTube Music (`music.`) subdomains resolve to YouTube [#36](https://github.com/vigetlabs/craft-videoembed/issues/36) [#42](https://github.com/vigetlabs/craft-videoembed/pull/42)
+- `getYouTubeIdFromUrl()` no longer throws a `TypeError` on array-valued `?v[]=` query params [#34](https://github.com/vigetlabs/craft-videoembed/issues/34) [#42](https://github.com/vigetlabs/craft-videoembed/pull/42)
+
+### Security
+- Vimeo private-hash parsing rejects array-valued `?h[]=` params (previously an uncaught `TypeError`) and validates the hash against `[A-Za-z0-9]`, so untrusted characters can't be interpolated into the embed or canonical URL [#49](https://github.com/vigetlabs/craft-videoembed/issues/49) [#58](https://github.com/vigetlabs/craft-videoembed/pull/58)
+- YouTube video IDs are validated against `[A-Za-z0-9_-]` before being interpolated into embed and image URLs [#42](https://github.com/vigetlabs/craft-videoembed/pull/42)
+
 ## 3.1.0 - 2026-06-16
 ### Added
 - Exposed `isVertical` for YouTube Shorts [#40](https://github.com/vigetlabs/craft-videoembed/pull/40)


### PR DESCRIPTION
Final Phase 2 grouping of the PR #42 follow-ups: the release documentation. CHANGELOG-only.

Addresses #55. Sequenced per `docs/plans/2026-07-08-001-fix-pr42-followups-plan.md`.

## Version: 3.2.0 (minor)

The `#55` ticket originally said to fold these into the 3.1.0 entry, but **3.1.0 is already tagged and released** (GitHub release, 2026-06-17), and `#42` plus every follow-up (`#49`–`#54`) landed *after* that tag. So these go under a **new `## 3.2.0` entry**, leaving the shipped 3.1.0 section untouched.

**Why a minor, not a patch:** `#51` adds scheme-less URL support — new functionality, which is a minor bump under SemVer. The `Changed`/`Removed` items are behavior changes, but each only affects URLs that were already broken, look-alike hosts, or the deprecated (Vimeo-unsupported) Froogaloop path, so theyre documented with an upgrade note rather than treated as a major break. Froogaloop removal is kept as-is per decision — Vimeos Player SDK no longer needs the `api=1`/`player_id` params.

## Whats documented

Everything consumer-facing since 3.1.0, grouped by Keep a Changelog category (Added / Changed / Removed / Fixed / Security) — scheme-less support, the `getEmbedUrl` https/Froogaloop/un-deprecation changes, strict host+scheme matching, `isVideoUrl` alignment, the reserved-segment/stacked-prefix/subdomain fixes, and the Vimeo-hash + YouTube-ID validation hardening. Each line links its issue and delivering PR.

## README

**No change needed** — the ticket flagged a stale protocol-relative Output example, but the README already shows `https://www.youtube.com/embed/6xWpo5Dn254?rel=0` (corrected by #48) and documents the safe `getVideoData` + `{% if video %}` pattern with no stale Froogaloop/protocol-relative examples.

## Verification

- All 11 referenced issue/PR links resolve; the [Vimeo Player SDK](https://developer.vimeo.com/player/sdk) upgrade-note link is confirmed as the official page.
- The released `3.1.0` entry is untouched.
- No code changes, so the test suite is unaffected.

## Plan complete

This is the last grouping. With it, all seven PR #42 follow-ups (#49–#55) are delivered across #56 (baseline), #58 (parser hardening), #59 (URL contract), and this PR.